### PR TITLE
docs: approve privacy, educational safety, support, retention, and incident policies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ CHANGELOG.md
 !/docs/agents/**
 !/docs/adr/
 !/docs/adr/**
+!/docs/policies/
+!/docs/policies/**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ This repository uses a single-context domain documentation layout. See `docs/age
 - `DESIGN.md`: approved tokens, navigation, responsive floors, accessibility baseline, exception process.
 - `CONTEXT.md`: canonical domain terms, legacy terminology, invariants.
 - `docs/adr/`: approved architectural seams. Start at `docs/adr/README.md`.
+- `docs/policies/`: data protection, retention, AI safety, educational scope, support, incident response, moderation, and the obligation-to-control map. Start at `docs/policies/README.md`.
 
 ### Delivery order
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ This repository uses a single-context domain documentation layout. See `docs/age
 - `DESIGN.md`: approved tokens, navigation, responsive floors, accessibility baseline, exception process.
 - `CONTEXT.md`: canonical domain terms, legacy terminology, invariants.
 - `docs/adr/`: approved architectural seams. Start at `docs/adr/README.md`.
+- `docs/policies/`: data protection, retention, AI safety, educational scope, support, incident response, moderation, and the obligation-to-control map. Start at `docs/policies/README.md`.
 
 ### Delivery order
 
@@ -34,3 +35,4 @@ Implement release work in dependency waves and keep tests inside each vertical s
 - Do not defer tests, authorization checks, observability, accessibility, migrations, or rollback notes to an unspecified later task.
 - Preserve the Course → Module → Topic vocabulary; `Chapter` is a legacy route and storage term only. `CONTEXT.md` is the authority on every domain term.
 - Stop for a `ready-for-human` decision instead of silently choosing pricing, policy, destructive migration, AI safety, or final visual direction.
+- Never implement a policy clause marked `PENDING LEGAL REVIEW` in `docs/policies/`, and never publish it to learners.

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Product, design, domain, and architecture decisions are written down and binding
 | [DESIGN.md](DESIGN.md) | Approved tokens, typography, navigation model, responsive floors, motion policy, accessible state vocabulary, exception process |
 | [CONTEXT.md](CONTEXT.md) | Canonical domain terms, legacy terminology, naming rules, system invariants |
 | [docs/adr/](docs/adr/README.md) | Approved architectural seams: identity and RBAC, entitlements, RLS, completion, outbox, AI, releases |
+| [docs/policies/](docs/policies/README.md) | Operating policies: data protection, retention and deletion, AI safety, educational scope, support, incident response, moderation, and the obligation-to-control map |
 | [docs/agents/](docs/agents/domain.md) | Shared workflow for coding agents: issue tracker, triage labels, domain docs, delivery order |
 
 ## Design system

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -10,6 +10,7 @@ These exist and are binding. Before changing a domain area, read:
 - [`PRODUCT.md`](../../PRODUCT.md) for audiences, purpose, the paid/free boundary, anti-references, and open product decisions.
 - [`DESIGN.md`](../../DESIGN.md) for approved tokens, the navigation model, responsive floors, the accessible state vocabulary, and the exception process.
 - The relevant records under [`docs/adr/`](../adr/README.md) for the architectural seam you are about to cross.
+- The relevant policy under [`docs/policies/`](../policies/README.md) when the change touches personal data, retention, AI, moderation, support, or incident behavior.
 - The phase specifications under `docs/phase-*.md` for implementation history.
 
 Where a document and the code disagree, the document is the decision and the code is the defect, unless an ADR says otherwise. Create or update domain terminology and ADRs only when a decision has been approved, and record the approver by name.

--- a/docs/policies/01-data-protection.md
+++ b/docs/policies/01-data-protection.md
@@ -1,0 +1,119 @@
+# 01. Data protection and privacy
+
+- **Status:** Approved, with marked clauses pending legal review
+- **Approver:** Prince Agyei Tuffour (@nanaagyei), 2026-08-30
+- **Public counterpart:** `/privacy`, generated from `lib/legal-content.ts`
+
+## Roles
+
+The Akomapa Health Foundation is the **controller** for all personal data
+processed by Akomapa Academy. Every third party listed in the inventory below
+is a **processor** acting on the Foundation's instructions, except Stripe,
+which acts as an independent controller for its own fraud-prevention and
+regulatory obligations.
+
+**PENDING LEGAL REVIEW:** a data processing agreement must be in place with
+each processor before the v1 launch, and the transfer mechanism for each must
+be confirmed. Tracked in policy 08.
+
+## Data inventory
+
+Every store that holds personal data, what it holds, and who processes it. This
+inventory is the input to the retention schedule in
+[policy 02](02-retention-and-deletion.md).
+
+| Data class | Contents | Store and processor | Sensitivity |
+| --- | --- | --- | --- |
+| Identity | Clerk user id, email, first and last name, image URL, Google sign-in linkage | Clerk; mirrored to `User` in PostgreSQL (Supabase) | Personal |
+| Staff profile | `bio`, `title`, `specialization` for Faculty and Administrators | `User` (Supabase) | Personal, self-supplied, learner-visible |
+| Learning records | `Enrollment`, `UserProgress`, `QuizAttempt`, `QuizAnswer`, `CaseStudyAttempt`, `LearningStreak`, `UserBadge` | Supabase | Education record |
+| Assessment keys | `QuestionOption.isCorrect` | Supabase | Not personal, but never disclosed to learners pre-submission or logged |
+| Reflection | `JournalEntry` content, default `isPrivate: true` | Supabase | Sensitive. Private learner reflection |
+| Community | `ForumPost`, `ForumComment`, `PostLike`, `CommentLike` | Supabase | Personal, learner-published |
+| Credentials | `Certificate`, including `certificateNumber` and `pdfUrl` | Supabase; PDF via UploadThing | Personal, and partly public by design at `/verify` |
+| Payments | `Purchase`, `StripCustomer.stripeCustomerId` | Supabase; card data and transaction records held by Stripe only | Financial. No card data ever reaches Akomapa systems |
+| Uploads | Course attachments, images, certificate PDFs | UploadThing | Mixed |
+| Video | Course video assets and playback ids (`MuxData`) | Mux | Content, plus Mux-side viewing telemetry |
+| Preferences | `UserSettings` including theme and notification flags | Supabase | Personal, low sensitivity |
+| Operational logs | Request and error logs emitted by `lib/logger.ts` and captured by the platform | Vercel | May contain IP address and user agent |
+
+**No analytics or product-telemetry SDK is installed.** There is no Vercel
+Analytics, Sentry, PostHog, or equivalent in `package.json`. The only telemetry
+is the platform request and error logging above. Any future addition is a
+change to this inventory and to the public privacy page.
+
+## Lawful bases
+
+Stated for GDPR and UK GDPR; the equivalent Ghanaian and US analyses follow the
+same processing purposes.
+
+| Purpose | Lawful basis |
+| --- | --- |
+| Creating and operating an account | Contract |
+| Delivering Courses, recording progress, grading Quizzes | Contract |
+| Issuing and publicly verifying Certificates | Contract, and legitimate interest in credential integrity for the public verification surface |
+| Taking payment for a Course | Contract, and legal obligation for retained financial records |
+| Community and Journal features | Contract |
+| Moderating content and preventing abuse | Legitimate interest |
+| Security logging, incident investigation, and fraud prevention | Legitimate interest |
+| Notifying learners about their own activity | Consent, through `UserSettings`. **Not currently exercised: no email delivery capability exists.** See policy 05 |
+
+## Never logged
+
+Reproduced from [CONTEXT.md](../../CONTEXT.md) because it is a privacy control,
+not only an engineering convention. The following must never appear in logs,
+telemetry, error reports, analytics, or support tooling:
+
+secrets and tokens; raw payment data; `JournalEntry` content; private Community
+content; answer keys (`QuestionOption.isCorrect`); and, when AI Pro exists, AI
+prompts and completions. Telemetry uses correlation ids and safe identifiers.
+
+## Data subject rights
+
+The Foundation honours these rights for **every** learner, without a
+jurisdiction test, because segmenting rights by geography would be both harder
+to operate and worse for the audience PRODUCT.md describes:
+
+access, rectification, erasure, restriction, portability (a machine-readable
+export of the learner's own account, learning records, Journal, and Community
+content), objection to processing based on legitimate interest, and the right
+to complain to a supervisory authority.
+
+**How a request is made and handled.** Requests arrive through the contact
+route in `siteConfig.contactUrl`. Identity is verified against the Clerk
+account before anything is disclosed or deleted. The target is acknowledgement
+within 5 working days and completion within 30 days, extendable once by 30 days
+for a complex request, with the learner informed.
+
+**PENDING LEGAL REVIEW:** the 30 day completion target is the GDPR one month
+standard. Confirm the Ghanaian Act 843 timescale and any US state deadline that
+is shorter, and adopt the shortest.
+
+**No self-service path exists yet.** Deletion and export are manual operations
+today. The self-service account deletion and export flow is tracked in policy
+08.
+
+## International transfers
+
+Data is processed in the United States and in whichever regions the processors
+operate. For EEA and UK learners this is a restricted transfer.
+
+**PENDING LEGAL REVIEW:** confirm the transfer mechanism for each processor
+(Standard Contractual Clauses, the UK Addendum, or an adequacy decision) and
+record it in policy 08 before launch.
+
+## Children
+
+The Academy is intended for learners in or beyond health-professional training
+and is not directed at children. Accounts are not knowingly created for anyone
+under 16. Where an account is found to belong to someone under 16 it is
+suspended and the data deleted under [policy 02](02-retention-and-deletion.md).
+
+## Public by design
+
+Certificate verification at `/verify` is deliberately public and
+unauthenticated: a credential nobody can check is not a credential. A
+verification lookup may show the learner name, Course, and issue date tied to
+that certificate number. This is disclosed at issuance and in the public
+privacy page, and it is the one place where deletion does not remove a
+learner-identifying record. See [policy 02](02-retention-and-deletion.md).

--- a/docs/policies/01-data-protection.md
+++ b/docs/policies/01-data-protection.md
@@ -90,8 +90,7 @@ standard. Confirm the Ghanaian Act 843 timescale and any US state deadline that
 is shorter, and adopt the shortest.
 
 **No self-service path exists yet.** Deletion and export are manual operations
-today. The self-service account deletion and export flow is tracked in policy
-08.
+today. The self-service flow is tracked in [#117](https://github.com/akomapahealth/akomapa-lms/issues/117).
 
 ## International transfers
 

--- a/docs/policies/02-retention-and-deletion.md
+++ b/docs/policies/02-retention-and-deletion.md
@@ -70,8 +70,11 @@ Answer keys, other learners' data, and internal moderation notes are excluded.
 ## Current capability gap
 
 **Deletion and export are manual operations today.** There is no self-service
-flow, no scheduled job to enforce these periods, and no `vercel.json` cron
-configured. Until the work in policy 08 lands, retention is enforced by a named
-person following this schedule, and every execution is recorded. This is stated
+flow ([#117](https://github.com/akomapahealth/akomapa-lms/issues/117)), no scheduled job to enforce these periods
+([#118](https://github.com/akomapahealth/akomapa-lms/issues/118)), and no `vercel.json` cron configured. The public page still
+says "a reasonable period" and is corrected by [#119](https://github.com/akomapahealth/akomapa-lms/issues/119). Certificate
+revocation, offered above as the alternative to deletion, is not implemented
+([#120](https://github.com/akomapahealth/akomapa-lms/issues/120)). Until those land, retention is enforced by a named person
+following this schedule, and every execution is recorded. This is stated
 plainly rather than implied, because a published policy promising automatic
 deletion that does not happen is worse than no policy.

--- a/docs/policies/02-retention-and-deletion.md
+++ b/docs/policies/02-retention-and-deletion.md
@@ -1,0 +1,77 @@
+# 02. Retention and deletion
+
+- **Status:** Approved, with retention minimums pending legal review
+- **Approver:** Prince Agyei Tuffour (@nanaagyei), 2026-08-30
+- **Public counterpart:** the "How long we keep information" section of `/privacy`, which currently says only "a reasonable period" and must be replaced with these periods
+
+## Principle
+
+Data is kept for as long as it serves the purpose it was collected for, plus
+any period the law requires, and then it is deleted or de-identified. A
+retention period that cannot be named is not a retention policy, which is why
+every row below carries a number.
+
+## Retention schedule
+
+Periods run from the trigger named in each row. "De-identify" means severing
+the link to a person while keeping the record for aggregate reporting.
+
+| Data class | Store | Trigger | Retention | Then |
+| --- | --- | --- | --- | --- |
+| Identity | Clerk | Account deletion request | 30 days | Delete from Clerk; the mirrored `User` row is anonymised, not removed, so foreign keys survive |
+| Account mirror | `User` (Supabase) | Account deletion request | 30 days | Anonymise: clear email, names, image, `bio`, `title`, `specialization`; retain the id |
+| Learning records | `Enrollment`, `UserProgress`, `QuizAttempt`, `QuizAnswer`, `CaseStudyAttempt` | Account deletion request | 30 days | De-identify. Aggregate outcome data is retained for programme evaluation |
+| Learning streaks and badges | `LearningStreak`, `UserBadge` | Account deletion request | 30 days | Delete |
+| Journal entries | `JournalEntry` | Account deletion request | 30 days | **Delete outright.** Private reflection is never de-identified and retained |
+| Community content | `ForumPost`, `ForumComment`, likes | Account deletion request | 30 days | Author is anonymised and the content remains, so threads stay coherent. A learner may instead request removal of specific posts, which is honoured |
+| Certificates | `Certificate` | Never deleted while the credential stands | Indefinite | Retained. See "What survives deletion" |
+| Certificate PDFs | UploadThing | Certificate revoked | 30 days | Delete the asset; the verification record remains |
+| Payment records | `Purchase`, `StripCustomer` | Transaction date | **7 years, PENDING LEGAL REVIEW** | Retain for nonprofit accounting and audit. Confirm the correct minimum under Ghanaian and US law |
+| Card and transaction data | Stripe only | Governed by Stripe | Per Stripe's retention | Never held by Akomapa systems |
+| Course uploads and attachments | UploadThing | Course unpublished and archived | 12 months | Delete |
+| Video assets | Mux | Course archived | 12 months | Delete the asset and `MuxData` row |
+| Preferences | `UserSettings` | Account deletion request | 30 days | Delete |
+| Operational logs | Vercel | Log write | Platform default retention | Expire. Never exported into another store |
+
+The 30 day window on deletion requests is a grace period that lets a learner
+reverse an accidental deletion and lets the Foundation resolve a payment
+dispute. It is disclosed at the point of request.
+
+**PENDING LEGAL REVIEW:** the 7 year financial retention and the 30 day grace
+period both need confirmation against Ghanaian Act 843, US nonprofit
+record-keeping rules, and the GDPR storage-limitation principle. Adopt the
+shortest period that satisfies all of them.
+
+## What survives deletion
+
+Deleting an account does not delete:
+
+1. **Issued Certificates and their verification records.** A credential that
+   disappears when its holder deletes their account is worthless to the
+   employer or institution relying on it. The verification page continues to
+   show the name that appeared on the credential. This is disclosed at
+   issuance, in the public privacy page, and in this policy. A learner who
+   wants the credential withdrawn requests **revocation**, which marks it
+   invalid and stops it verifying, rather than deletion.
+2. **Financial records** required for accounting and audit, held for the period
+   above.
+3. **Moderation records** where content was removed for a safety violation,
+   retained under [policy 07](07-moderation-and-appeals.md) so a banned actor
+   cannot erase the record by deleting the account.
+4. **Aggregate, de-identified learning outcomes** used for programme
+   evaluation, which cannot be traced back to a person.
+
+## Export
+
+A learner may request a machine-readable export of their identity, learning
+records, Journal entries, Community content, Certificates, and preferences.
+Answer keys, other learners' data, and internal moderation notes are excluded.
+
+## Current capability gap
+
+**Deletion and export are manual operations today.** There is no self-service
+flow, no scheduled job to enforce these periods, and no `vercel.json` cron
+configured. Until the work in policy 08 lands, retention is enforced by a named
+person following this schedule, and every execution is recorded. This is stated
+plainly rather than implied, because a published policy promising automatic
+deletion that does not happen is worse than no policy.

--- a/docs/policies/03-ai-acceptable-use-and-safety.md
+++ b/docs/policies/03-ai-acceptable-use-and-safety.md
@@ -1,0 +1,96 @@
+# 03. AI acceptable use and safety
+
+- **Status:** **Proposed.** Not approved, and not implementable
+- **Approver:** pending, gated on [#70](https://github.com/akomapahealth/akomapa-lms/issues/70)
+- **Scope:** binds AI Pro before it may be enabled for anyone
+
+## Standing
+
+AI Pro is out of v1 scope. See
+[PRODUCT.md](../../PRODUCT.md#ai-pro) and
+[ADR 0006](../adr/0006-ai-provider-abstraction.md), which is itself Proposed.
+
+This policy exists so that the privacy, retention, and safety obligations of an
+AI feature are written down **before** the boundaries that must satisfy them
+are built in Waves 1 and 2. It is deliberately not approved: the threat model,
+safety rubric, and evaluation dataset that would justify approval are the
+deliverable of #70. Nothing here may be implemented, published, or relied on
+until #70 closes and an approver is recorded above.
+
+## Rules proposed
+
+### Provider processing
+
+1. All model access goes through the single provider seam in ADR 0006. No
+   feature imports a vendor SDK directly.
+2. The provider is a **processor**, not a controller, under a data processing
+   agreement executed before any learner data reaches it.
+3. **No training on Academy data.** The contract must prohibit the provider
+   from using prompts, completions, or retrieved Course content to train or
+   improve models. If a provider cannot commit to this, it is not eligible.
+4. The provider, its processing regions, and its retention are disclosed in the
+   public privacy page and added to the inventory in
+   [policy 01](01-data-protection.md) before the feature is enabled.
+
+### What may and may not be sent
+
+5. Only the learner's own prompt and Course content that learner is already
+   entitled to read may be sent. Retrieval is scoped by the same entitlement
+   as direct reading, per [ADR 0002](../adr/0002-enrollment-as-canonical-entitlement.md).
+6. **Never sent to a provider:** Journal Entry content, private Community
+   content, answer keys, other learners' data, payment data, and identity data
+   beyond an opaque correlation id.
+
+### Behaviour
+
+7. **Grounded or refused.** A learner-facing answer is grounded in retrieved
+   Course content and cites it. An answer that cannot be grounded is refused,
+   not improvised.
+8. **Uncertainty is stated,** not smoothed over.
+9. **Individual clinical guidance is refused,** with a redirect to Course
+   material and to a qualified human. This inherits
+   [policy 04](04-educational-scope.md) and is a launch gate, not a quality
+   target.
+10. **No assessment authority.** AI output never sets or alters a Quiz score,
+    grade, completion, Badge, or Certificate. Generated Quiz variants require
+    Faculty review before a learner sees them.
+11. **No answer leakage.** An AI feature must not reveal `isCorrect` data or
+    the answer to an assessment the learner has not submitted.
+
+### Acceptable use by learners
+
+12. Prohibited: attempting to extract answer keys or other learners' data;
+    prompt injection or jailbreak attempts; seeking individualised medical
+    advice; generating harmful, harassing, or academically dishonest content;
+    and automated or bulk access. Enforcement follows
+    [policy 07](07-moderation-and-appeals.md).
+
+### Retention of conversations
+
+13. **PENDING LEGAL REVIEW and #70:** proposed retention is 90 days for AI
+    conversations, deleted on account deletion with no de-identified residue,
+    and never used for training. Confirm against the abuse-investigation need
+    before adoption.
+14. Prompts and completions are never logged. Telemetry records correlation
+    id, token counts, latency, cost, and outcome only, per
+    [policy 01](01-data-protection.md).
+
+### Operations
+
+15. Quota, cost, and concurrency are checked before a call reaches a provider.
+    There is no unmetered path.
+16. A single server-side kill switch disables learner-facing AI immediately
+    without a deploy, and is exercised in a drill before AI is enabled for
+    anyone.
+17. Learner-facing AI is disabled by default and stays disabled until #70, #72
+    to #75, #78, and the relevant evaluation gates in #79 are all complete.
+18. An AI outage or a lapsed AI subscription never removes Course access.
+
+## What #70 must add before this can be approved
+
+The threat model (prompt injection, cross-Course retrieval, sensitive-data
+leakage, tool misuse, answer leakage, abuse, billing bypass, provider
+compromise); the educational safety rubric with pass thresholds; the versioned,
+de-identified evaluation dataset with expected citations and refusals; the
+named owners of launch thresholds, escalation, model-change review, and the
+kill switch; and the cost posture.

--- a/docs/policies/04-educational-scope.md
+++ b/docs/policies/04-educational-scope.md
@@ -1,0 +1,61 @@
+# 04. Educational scope and medical advice
+
+- **Status:** Approved
+- **Approver:** Prince Agyei Tuffour (@nanaagyei), 2026-08-30
+- **Public counterpart:** the "This is an education platform, not a clinic" notice on `/privacy` and the "Educational use only. Not medical advice." notice on `/terms`
+
+## What the Academy is
+
+Akomapa Academy is an educational programme. It teaches global health
+leadership and ethics. It is not a healthcare provider, not a clinical decision
+support tool, not an electronic health record, and not a source of medical
+advice for any individual patient.
+
+Clinical care and patient data are handled by Akomapa Community Learning and
+Care Hubs and the Nkwapa digital health platform, which are separate systems
+governed by separate policies. Nothing in the Academy connects to them.
+
+## No protected health information
+
+Learners, Faculty, and Administrators must not submit identifiable patient
+information to any Academy surface: not to a Journal Entry, not to a Community
+Post or Comment, not to a Case Study Attempt, not to an upload, and not to a
+support request.
+
+Case Studies and discussion prompts use constructed or fully de-identified
+scenarios. Faculty authoring a Case Study are responsible for confirming that
+no real patient is identifiable from it, including by combination of details.
+
+**When PHI is submitted anyway**, it is treated as a security incident under
+[policy 06](06-incident-response.md) at severity SEV2 or higher:
+
+1. The content is removed from learner-visible surfaces immediately.
+2. The submission is deleted rather than de-identified, including from any
+   backup where that is technically possible, and where it is not, the
+   limitation is recorded.
+3. The submitter is contacted and told why, in terms that educate rather than
+   punish, because this is usually a well-meaning clinical instinct.
+4. The incident is logged. Repeated submission after warning is a moderation
+   matter under [policy 07](07-moderation-and-appeals.md).
+
+## Educational limitations disclosed to learners
+
+Every assessment, Case Study, and Certificate carries the same underlying
+truth, and learner-facing copy must not overstate it:
+
+- Course content teaches principles and reasoning, not protocols to apply to a
+  specific patient.
+- A Certificate attests that a named person completed a named Course on a named
+  date. It is not a licence, not a credential to practise, not accreditation,
+  and not a statement of clinical competence.
+- Quiz scores measure understanding of Course material. They do not measure
+  clinical ability.
+- Content reflects the state of the field at authoring time and may age.
+
+## Binding on future AI
+
+Any AI feature inherits every rule in this policy without exception, and adds
+the refusal requirements in
+[policy 03](03-ai-acceptable-use-and-safety.md). An AI feature that gives
+individualised clinical guidance would violate this policy, which is why the
+refusal behaviour is a launch gate rather than a quality target.

--- a/docs/policies/05-support-and-service-levels.md
+++ b/docs/policies/05-support-and-service-levels.md
@@ -1,0 +1,68 @@
+# 05. Support and service levels
+
+- **Status:** Approved
+- **Approver:** Prince Agyei Tuffour (@nanaagyei), 2026-08-30
+
+## What is actually true
+
+Akomapa Academy is run by a small nonprofit team. There is no paid on-call
+rota. This policy describes best-effort support with response **targets**, not
+contractual guarantees, because publishing an SLA the team cannot staff would
+be a promise broken on the first bad week.
+
+## Channels and hours
+
+The contact route in `siteConfig.contactUrl` is the single support channel.
+Community posts are not a support channel; a support question posted publicly
+is redirected, and anything containing personal or payment details is removed
+under [policy 07](07-moderation-and-appeals.md).
+
+Working hours span Ghana (GMT) and US Eastern business hours, Monday to Friday,
+excluding public holidays in both locations.
+
+## Response targets
+
+Targets are measured from receipt to first substantive human response, in
+working hours.
+
+| Request | Target |
+| --- | --- |
+| Cannot sign in, or lost access to a purchased Course | 1 working day |
+| Payment taken but no access granted | 1 working day |
+| Certificate not issued after completion, or verification failing | 2 working days |
+| Data subject request (access, export, deletion, correction) | Acknowledge in 5 working days; complete per [policy 01](01-data-protection.md) |
+| Moderation report of harmful content | Same working day for anything involving safety; 2 working days otherwise |
+| Moderation appeal | 5 working days |
+| Content error or general question | 5 working days |
+
+Missing a target is not an incident on its own. A pattern of missed targets is
+reviewed and either the staffing or the target changes, and the published
+target is corrected rather than quietly retained.
+
+## Ownership and escalation
+
+Support is owned by the Foundation's programme staff. Escalation is to a named
+person, currently Prince Agyei Tuffour (@nanaagyei), for anything that is a
+suspected security incident, a data subject request, a payment dispute, a
+safety report, or a moderation appeal.
+
+There is **no out-of-hours escalation path**. An incident raised outside
+working hours is handled at the start of the next working period unless the
+named escalation contact is reachable and chooses to act sooner. Severity
+definitions and the incident timeline are in
+[policy 06](06-incident-response.md).
+
+## Not promised
+
+Stated explicitly so nothing is inferred:
+
+- No uptime guarantee, no service credits, no refund tied to availability.
+- **No email notification.** The `emailOnBadgeEarned`, `emailOnForumReply`, and
+  `emailOnFacultyComment` flags in `UserSettings` are stored preferences with
+  **no delivery mechanism**: no email provider is installed. Until that changes,
+  no policy, page, or interface may imply that email is sent. Tracked in
+  [policy 08](08-obligation-to-control-map.md).
+- No live chat, no telephone support, no guaranteed response outside working
+  hours.
+- No support for a learner's own device, browser, or network conditions beyond
+  the responsive floors in [DESIGN.md](../../DESIGN.md).

--- a/docs/policies/05-support-and-service-levels.md
+++ b/docs/policies/05-support-and-service-levels.md
@@ -61,7 +61,7 @@ Stated explicitly so nothing is inferred:
   `emailOnFacultyComment` flags in `UserSettings` are stored preferences with
   **no delivery mechanism**: no email provider is installed. Until that changes,
   no policy, page, or interface may imply that email is sent. Tracked in
-  [policy 08](08-obligation-to-control-map.md).
+  [#121](https://github.com/akomapahealth/akomapa-lms/issues/121).
 - No live chat, no telephone support, no guaranteed response outside working
   hours.
 - No support for a learner's own device, browser, or network conditions beyond

--- a/docs/policies/06-incident-response.md
+++ b/docs/policies/06-incident-response.md
@@ -1,0 +1,97 @@
+# 06. Incident response
+
+- **Status:** Approved, with notification deadlines pending legal review
+- **Approver:** Prince Agyei Tuffour (@nanaagyei), 2026-08-30
+
+## Severity
+
+Severity is set by impact, not by cause, and by the worst plausible reading of
+the evidence available at the time. Severity is raised freely and lowered only
+with a reason recorded.
+
+| Level | Definition | Examples |
+| --- | --- | --- |
+| **SEV1** | Personal data is exposed to someone not entitled to it, or credential integrity is broken | Cross-learner data disclosure; Journal Entries readable by another account; a forged or spoofable Certificate; answer keys reachable before submission; database credentials leaked |
+| **SEV2** | A security or safety control has failed but no confirmed exposure, or a payment integrity failure | Authorization check missing on a route; RLS policy disabled in production; PHI submitted to a learner surface; payment taken with no access granted; a critical dependency vulnerability with a reachable path |
+| **SEV3** | Learners cannot use a core journey | Sign-in failing; Course player down; Quiz submission failing; Certificate issuance stalled |
+| **SEV4** | Degraded or cosmetic, with a workaround | Slow video start; a broken image; an analytics gap |
+
+A suspected SEV1 is handled as a SEV1 until disproved.
+
+## Roles
+
+Roles are held by people, not teams, given the size of the group. One person
+may hold several, but the incident lead never also does the remediation for a
+SEV1: the lead's job is to keep the timeline and the decisions honest.
+
+- **Incident lead:** runs the response, owns the timeline, decides severity,
+  decides on notification. Currently Prince Agyei Tuffour (@nanaagyei).
+- **Responder:** investigates and remediates.
+- **Communications owner:** learner and authority communication. Currently the
+  incident lead.
+
+## Timeline
+
+1. **Detect and declare.** Anyone may declare. Declaration starts a written
+   timeline, kept from the first minute rather than reconstructed afterwards.
+2. **Contain**, and prefer containment over diagnosis. Disable the affected
+   route, revoke the credential, or take the feature down. Availability is
+   sacrificed to stop exposure, never the reverse.
+3. **Preserve evidence** before remediating: logs, database state, and the
+   deploy that introduced it. Remediation that destroys the evidence makes the
+   postmortem impossible.
+4. **Assess scope.** Which data, how many people, which regions, from when to
+   when. Record what is known, what is suspected, and what is unknown, and keep
+   those three separate.
+5. **Remediate**, then verify the fix with a test that fails before it.
+6. **Notify**, per the section below.
+7. **Postmortem** within 5 working days for SEV1 and SEV2.
+
+## Notification
+
+**PENDING LEGAL REVIEW:** the deadlines below are the GDPR baseline. Confirm
+the Ghanaian Act 843 requirement and any US state breach-notification deadline
+that is shorter, and adopt the shortest.
+
+- **Supervisory authority:** within **72 hours** of becoming aware of a
+  personal data breach that is likely to risk people's rights, notify the
+  relevant authority, which may include the Ghana Data Protection Commission
+  and an EEA or UK authority. Notify late with an explanation rather than not
+  at all.
+- **Affected learners:** without undue delay where the breach is likely to
+  result in a high risk to them. The notice says what happened, what data, what
+  the Foundation is doing, and what the learner should do. It never minimises
+  and never blames the learner.
+- **Processors:** where a processor caused it, obtain their written account and
+  keep it with the timeline.
+- **Payment incidents:** notify Stripe per their requirements.
+
+A decision **not** to notify is recorded with its reasoning and reviewed by the
+incident lead. Silence is never the default.
+
+## Postmortem
+
+Blameless, written, and kept. It records the timeline with timestamps, the
+technical cause, the detection gap, the scope, what was and was not notified
+and why, and the actions taken. Every action becomes a tracked issue with an
+owner, and any action that would prevent a repeat of a SEV1 is a
+`release-blocker`.
+
+The postmortem asks what allowed the fault to reach production, not who wrote
+it. A postmortem that names a person as the cause is rejected and rewritten.
+
+## Known limitations
+
+Stated honestly, because a response plan that assumes capability it does not
+have will fail when used:
+
+- **No automated alerting.** Structured logging, correlation, traces, and
+  alerts are [#102](https://github.com/akomapahealth/akomapa-lms/issues/102);
+  health and readiness checks are
+  [#103](https://github.com/akomapahealth/akomapa-lms/issues/103). Until those
+  land, detection depends on someone noticing or a learner reporting.
+- **No verified restore.** Backup and restore have not been drilled;
+  [#104](https://github.com/akomapahealth/akomapa-lms/issues/104) owns that and
+  is itself blocked by this policy. Recovery time is therefore **unknown**, and
+  no RPO or RTO may be published until that drill has been performed.
+- **No out-of-hours rota.** See [policy 05](05-support-and-service-levels.md).

--- a/docs/policies/07-moderation-and-appeals.md
+++ b/docs/policies/07-moderation-and-appeals.md
@@ -1,0 +1,72 @@
+# 07. Moderation and appeals
+
+- **Status:** Approved
+- **Approver:** Prince Agyei Tuffour (@nanaagyei), 2026-08-30
+- **Public counterpart:** the "Acceptable use" and "Your content" sections of `/terms`
+
+## Standards
+
+The Community exists so learners can think aloud with peers. Moderation
+protects that, and nothing more. Disagreement, difficult questions, and
+unfinished thinking are the point and are never moderated.
+
+Removed: harassment, abuse, and discriminatory content; identifiable patient
+information, per [policy 04](04-educational-scope.md); doxxing and other
+people's personal data; answer keys, Quiz content, and coordinated academic
+dishonesty; spam, promotion, and recruitment; content that is illegal in Ghana
+or the United States.
+
+## Actions
+
+Proportionate, and escalating only on repetition. Every action is recorded with
+the actor, the reason, and the timestamp.
+
+| Action | When | Notice to the author |
+| --- | --- | --- |
+| Edit or redact | A single element breaches, for example a patient detail in an otherwise good post | Yes, with the reason |
+| Remove content | The content itself breaches | Yes, with the reason and the appeal path |
+| Lock a thread | The thread has stopped being useful | Announced in the thread |
+| Warn | First or second breach | Yes |
+| Suspend | Repeated breach after warning, or a single serious one | Yes, with duration and the appeal path |
+| Ban | Severe or persistent breach | Yes, with the appeal path |
+
+**Immediate removal without prior warning** applies only to identifiable
+patient information, doxxing, and content that presents a safety risk. The
+notice still follows.
+
+Suspension of Community access is separate from Course entitlement: a suspended
+learner keeps access to Courses they are entitled to unless the
+`Enrollment.status` is separately set to `SUSPENDED` for cause. Losing forum
+access must never quietly remove something a learner paid for.
+
+## Appeals
+
+Every action is appealable through the contact route in
+`siteConfig.contactUrl`. Target response is 5 working days
+([policy 05](05-support-and-service-levels.md)).
+
+An appeal is reviewed by someone other than the person who took the action
+where the team size allows it, and where it does not, that fact is recorded in
+the decision. Outcomes are uphold, reduce, or reverse. A reversal restores the
+content where it is technically possible and says so where it is not.
+
+## Audit trail
+
+Moderation actions are recorded so they can be reviewed and reversed. The
+record survives the author's account deletion, per
+[policy 02](02-retention-and-deletion.md), so that a banned actor cannot erase
+the record by deleting the account. The record holds the action, the actor, the
+reason, the timestamp, and the appeal outcome. It never holds the removed
+content itself where that content was removed for containing patient
+information.
+
+Moderation notes are internal and are excluded from a learner's data export.
+
+## Current capability gap
+
+Moderation today is manual: the admin Community surface allows pinning,
+locking, and removal, but there is **no consolidated audit trail and no
+reversible-action tooling**.
+[#89](https://github.com/akomapahealth/akomapa-lms/issues/89) owns that. Until
+it lands, the audit trail is maintained by hand by the acting Administrator,
+and this policy's guarantees depend on that discipline.

--- a/docs/policies/08-obligation-to-control-map.md
+++ b/docs/policies/08-obligation-to-control-map.md
@@ -38,7 +38,7 @@ awaiting review.
 | Right of access, rectification, erasure, restriction, portability, objection | Runbook | Manual process, [policy 01](01-data-protection.md). Requests via `siteConfig.contactUrl` |
 | Identity verified before disclosure or deletion | Runbook | Verified against the Clerk account |
 | Acknowledge in 5 working days, complete in 30 | Runbook | [policy 05](05-support-and-service-levels.md) targets |
-| Self-service account deletion and export | **Issue** | **To be filed.** No self-service flow exists |
+| Self-service account deletion and export | Issue | [#117](https://github.com/akomapahealth/akomapa-lms/issues/117). No self-service flow exists today |
 | Learner administration including suspension and deletion | Issue | [#88](https://github.com/akomapahealth/akomapa-lms/issues/88) |
 | Confirm the shortest statutory response deadline across regimes | **Legal** | Pending review, [policy 01](01-data-protection.md) |
 
@@ -47,11 +47,11 @@ awaiting review.
 | Obligation | Type | Control |
 | --- | --- | --- |
 | A named retention period for every data class | Runbook | Schedule in [policy 02](02-retention-and-deletion.md) |
-| Automatic enforcement of retention periods | **Issue** | **To be filed.** No scheduled job and no `vercel.json` cron exist |
+| Automatic enforcement of retention periods | Issue | [#118](https://github.com/akomapahealth/akomapa-lms/issues/118). No scheduled job and no `vercel.json` cron exist today |
 | Retention, cascades, and concurrency correct at the database layer | Issue | [#51](https://github.com/akomapahealth/akomapa-lms/issues/51) |
-| Public page states real periods, not "a reasonable period" | **Issue** | **To be filed.** Update `lib/legal-content.ts` and bump `siteConfig.legalEffectiveDate` |
+| Public page states real periods, not "a reasonable period" | Issue | [#119](https://github.com/akomapahealth/akomapa-lms/issues/119). Update `lib/legal-content.ts` and bump `siteConfig.legalEffectiveDate` |
 | Confirm the financial retention minimum and the deletion grace period | **Legal** | Pending review, [policy 02](02-retention-and-deletion.md) |
-| Certificates survive account deletion, and revocation is the alternative | Disclosure, **Issue** | Disclosed in policy 02. **Revocation is not implemented**; to be filed |
+| Certificates survive account deletion, and revocation is the alternative | Disclosure, Issue | Disclosed in policy 02. Revocation is not implemented: [#120](https://github.com/akomapahealth/akomapa-lms/issues/120) |
 
 ## Payments
 
@@ -87,7 +87,7 @@ awaiting review.
 | --- | --- | --- |
 | Single support channel and published targets | Disclosure | [policy 05](05-support-and-service-levels.md); `siteConfig.contactUrl` |
 | Named escalation contact | Runbook | Policy 05 |
-| Do not imply email notification that cannot be sent | **Issue** | **To be filed.** `UserSettings.emailOn*` flags have no delivery mechanism; no email provider is installed |
+| Do not imply email notification that cannot be sent | Issue | [#121](https://github.com/akomapahealth/akomapa-lms/issues/121). `UserSettings.emailOn*` flags have no delivery mechanism; no email provider is installed |
 
 ## Incident response
 
@@ -124,9 +124,10 @@ and none may be implemented before it closes.
 
 ## Summary of what is not yet satisfied
 
-- **Five issues to be filed:** self-service deletion and export; automated
-  retention enforcement; public privacy page retention and AI update;
-  certificate revocation; the email-notification capability gap.
+- **Five issues filed and open:** [#117](https://github.com/akomapahealth/akomapa-lms/issues/117) self-service deletion and
+  export; [#118](https://github.com/akomapahealth/akomapa-lms/issues/118) automated retention enforcement; [#119](https://github.com/akomapahealth/akomapa-lms/issues/119) public
+  privacy and terms update; [#120](https://github.com/akomapahealth/akomapa-lms/issues/120) certificate revocation;
+  [#121](https://github.com/akomapahealth/akomapa-lms/issues/121) the email-notification capability gap.
 - **Six clauses pending legal review:** processor DPAs; transfer mechanisms;
   the data subject response deadline; the financial retention minimum and
   deletion grace period; breach notification deadlines; AI conversation

--- a/docs/policies/08-obligation-to-control-map.md
+++ b/docs/policies/08-obligation-to-control-map.md
@@ -1,0 +1,135 @@
+# 08. Obligation to control map
+
+- **Status:** Approved
+- **Approver:** Prince Agyei Tuffour (@nanaagyei), 2026-08-30
+
+Every obligation these policies create, mapped to the thing that satisfies it.
+An obligation whose control is an issue is **not yet satisfied**, and that is
+stated rather than implied.
+
+Legend: **Code** an implemented control; **Disclosure** learner-facing text;
+**Runbook** a documented manual procedure; **Issue** not yet built; **Legal**
+awaiting review.
+
+## Identity, access, and authorization
+
+| Obligation | Type | Control |
+| --- | --- | --- |
+| Only the account owner and authorised staff may read a learner's records | Code | Server-derived principal, [ADR 0001](../adr/0001-identity-authentication-and-rbac.md); `proxy.ts`, `lib/roles.ts` |
+| Access decisions cannot be forged from the browser | Code | ADR 0001 invariants; [CONTEXT.md](../../CONTEXT.md) |
+| A missing authorization check must not disclose data | Issue | RLS second layer, [ADR 0003](../adr/0003-rls-and-transaction-scoped-principal.md), [#43](https://github.com/akomapahealth/akomapa-lms/issues/43) |
+| Course access is granted only by entitlement | Code, Issue | [ADR 0002](../adr/0002-enrollment-as-canonical-entitlement.md); [#48](https://github.com/akomapahealth/akomapa-lms/issues/48) |
+| Role grants are not made by environment variable | Issue | Retire `TEACHER_ID`, [#42](https://github.com/akomapahealth/akomapa-lms/issues/42) |
+| Faculty and Administrator capabilities are separated | Issue | [#86](https://github.com/akomapahealth/akomapa-lms/issues/86) |
+
+## Confidentiality of sensitive content
+
+| Obligation | Type | Control |
+| --- | --- | --- |
+| Journal Entries are never logged, exported to analytics, or staff-visible while private | Code, Runbook | Never-logged list, [policy 01](01-data-protection.md), CONTEXT.md invariants |
+| Answer keys never reach a client pre-submission and are never logged | Code, Issue | CONTEXT.md invariants; Quiz binding [#41](https://github.com/akomapahealth/akomapa-lms/issues/41) |
+| No secrets, tokens, or raw payment data in logs | Code | `lib/logger.ts` logs tag and message only in production; gitleaks and the secret scan in CI |
+| Redacted structured logging with correlation ids | Issue | [#102](https://github.com/akomapahealth/akomapa-lms/issues/102) |
+
+## Data subject rights
+
+| Obligation | Type | Control |
+| --- | --- | --- |
+| Right of access, rectification, erasure, restriction, portability, objection | Runbook | Manual process, [policy 01](01-data-protection.md). Requests via `siteConfig.contactUrl` |
+| Identity verified before disclosure or deletion | Runbook | Verified against the Clerk account |
+| Acknowledge in 5 working days, complete in 30 | Runbook | [policy 05](05-support-and-service-levels.md) targets |
+| Self-service account deletion and export | **Issue** | **To be filed.** No self-service flow exists |
+| Learner administration including suspension and deletion | Issue | [#88](https://github.com/akomapahealth/akomapa-lms/issues/88) |
+| Confirm the shortest statutory response deadline across regimes | **Legal** | Pending review, [policy 01](01-data-protection.md) |
+
+## Retention and deletion
+
+| Obligation | Type | Control |
+| --- | --- | --- |
+| A named retention period for every data class | Runbook | Schedule in [policy 02](02-retention-and-deletion.md) |
+| Automatic enforcement of retention periods | **Issue** | **To be filed.** No scheduled job and no `vercel.json` cron exist |
+| Retention, cascades, and concurrency correct at the database layer | Issue | [#51](https://github.com/akomapahealth/akomapa-lms/issues/51) |
+| Public page states real periods, not "a reasonable period" | **Issue** | **To be filed.** Update `lib/legal-content.ts` and bump `siteConfig.legalEffectiveDate` |
+| Confirm the financial retention minimum and the deletion grace period | **Legal** | Pending review, [policy 02](02-retention-and-deletion.md) |
+| Certificates survive account deletion, and revocation is the alternative | Disclosure, **Issue** | Disclosed in policy 02. **Revocation is not implemented**; to be filed |
+
+## Payments
+
+| Obligation | Type | Control |
+| --- | --- | --- |
+| No card data reaches Akomapa systems | Code | Stripe Checkout; only `stripeCustomerId` and `Purchase` are stored |
+| Payment taken always results in access | Issue | Idempotent reconciliation, [#54](https://github.com/akomapahealth/akomapa-lms/issues/54); outbox [ADR 0005](../adr/0005-transactional-outbox-processing.md), [#69](https://github.com/akomapahealth/akomapa-lms/issues/69) |
+| Exact money representation | Issue | [#55](https://github.com/akomapahealth/akomapa-lms/issues/55). `Course.price` is currently a float |
+| Refund removes access without deleting payment evidence | Runbook, Issue | ADR 0002 states the rule; refund handling to be built with [#114](https://github.com/akomapahealth/akomapa-lms/issues/114) |
+
+## Educational scope
+
+| Obligation | Type | Control |
+| --- | --- | --- |
+| Not a clinic, not medical advice | Disclosure | Notices on `/privacy` and `/terms` via `lib/legal-content.ts` |
+| No identifiable patient information submitted | Disclosure, Runbook | [policy 04](04-educational-scope.md); handled as SEV2 under policy 06 |
+| Certificates are not a licence or accreditation | Disclosure | `/terms` certificates section; policy 04 |
+| Case Studies use constructed or de-identified scenarios | Runbook | Faculty responsibility, policy 04; authoring [#87](https://github.com/akomapahealth/akomapa-lms/issues/87) |
+
+## Moderation
+
+| Obligation | Type | Control |
+| --- | --- | --- |
+| Community standards published | Disclosure | `/terms` acceptable use |
+| Proportionate, notified, appealable actions | Runbook | [policy 07](07-moderation-and-appeals.md) |
+| Consolidated audit trail and reversible actions | Issue | [#89](https://github.com/akomapahealth/akomapa-lms/issues/89). Manual until then |
+| Community suspension does not remove paid Course access | Code, Runbook | Separate `Enrollment.status`, ADR 0002 |
+| Rich-text content cannot carry script injection | Issue | [#81](https://github.com/akomapahealth/akomapa-lms/issues/81) |
+
+## Support
+
+| Obligation | Type | Control |
+| --- | --- | --- |
+| Single support channel and published targets | Disclosure | [policy 05](05-support-and-service-levels.md); `siteConfig.contactUrl` |
+| Named escalation contact | Runbook | Policy 05 |
+| Do not imply email notification that cannot be sent | **Issue** | **To be filed.** `UserSettings.emailOn*` flags have no delivery mechanism; no email provider is installed |
+
+## Incident response
+
+| Obligation | Type | Control |
+| --- | --- | --- |
+| Severity definitions, roles, timeline, postmortem | Runbook | [policy 06](06-incident-response.md) |
+| 72 hour authority notification | Runbook, **Legal** | Policy 06; shortest applicable deadline pending review |
+| Detect incidents rather than wait for reports | Issue | [#102](https://github.com/akomapahealth/akomapa-lms/issues/102), [#103](https://github.com/akomapahealth/akomapa-lms/issues/103) |
+| Verified recovery, and a published RPO and RTO | Issue | [#104](https://github.com/akomapahealth/akomapa-lms/issues/104). **No RPO or RTO may be published until the drill is performed** |
+| Dependency vulnerabilities blocked before release | Code | `npm audit --audit-level=critical --omit=dev`, gitleaks, and CodeQL in `.github/workflows/ci.yml`; [#47](https://github.com/akomapahealth/akomapa-lms/issues/47) |
+
+## Processors and transfers
+
+| Obligation | Type | Control |
+| --- | --- | --- |
+| Processors named to learners | Disclosure | `/privacy` sharing section names Clerk, Stripe, Mux, UploadThing, Vercel, and the database host |
+| Data processing agreement with each processor | **Legal** | Pending review, [policy 01](01-data-protection.md) |
+| Transfer mechanism confirmed for EEA and UK data | **Legal** | Pending review, policy 01 |
+| Inventory updated when a processor is added | Runbook | Policy 01. Adding analytics or an email provider changes the inventory and the public page |
+
+## AI
+
+Every row is gated on [#70](https://github.com/akomapahealth/akomapa-lms/issues/70)
+and none may be implemented before it closes.
+
+| Obligation | Type | Control |
+| --- | --- | --- |
+| Provider seam, kill switch, quota, no prompt logging | Issue | [ADR 0006](../adr/0006-ai-provider-abstraction.md) (Proposed), [#71](https://github.com/akomapahealth/akomapa-lms/issues/71) |
+| No training on Academy data; DPA executed | **Legal** | [policy 03](03-ai-acceptable-use-and-safety.md) |
+| Grounding, citation, uncertainty, medical-advice refusal | Issue | Rubric in #70; [#75](https://github.com/akomapahealth/akomapa-lms/issues/75), [#78](https://github.com/akomapahealth/akomapa-lms/issues/78) |
+| Retrieval scoped by entitlement | Issue | [#74](https://github.com/akomapahealth/akomapa-lms/issues/74), ADR 0002 |
+| Evaluation thresholds before enabling | Issue | [#79](https://github.com/akomapahealth/akomapa-lms/issues/79) |
+| AI conversation retention | **Legal** | Proposed 90 days, policy 03 |
+
+## Summary of what is not yet satisfied
+
+- **Five issues to be filed:** self-service deletion and export; automated
+  retention enforcement; public privacy page retention and AI update;
+  certificate revocation; the email-notification capability gap.
+- **Six clauses pending legal review:** processor DPAs; transfer mechanisms;
+  the data subject response deadline; the financial retention minimum and
+  deletion grace period; breach notification deadlines; AI conversation
+  retention and the FERPA applicability question.
+- **No RPO or RTO exists** and none may be published before
+  [#104](https://github.com/akomapahealth/akomapa-lms/issues/104).

--- a/docs/policies/README.md
+++ b/docs/policies/README.md
@@ -1,0 +1,80 @@
+# Operating policies
+
+The policies that govern how Akomapa Academy handles personal data, AI, support,
+moderation, and incidents. They are internal source-of-truth documents. The
+learner-facing Privacy Policy and Terms of Service are generated from
+`lib/legal-content.ts` and rendered at `/privacy` and `/terms`; where a policy
+here changes what a learner is told, the public page is updated through the
+follow-up issue named in that policy, not silently.
+
+Approved by Prince Agyei Tuffour (@nanaagyei) on 2026-08-30 under issue
+[#38](https://github.com/akomapahealth/akomapa-lms/issues/38), except where a
+clause is marked **PENDING LEGAL REVIEW**. Those clauses are drafted, not
+approved, and must not be encoded in product code or published to learners
+until a qualified reviewer signs them off.
+
+## Index
+
+| Policy | Covers |
+| --- | --- |
+| [01 Data protection](01-data-protection.md) | Regulatory scope, controller and processor roles, the data inventory, lawful bases, data subject rights, international transfers |
+| [02 Retention and deletion](02-retention-and-deletion.md) | The retention schedule for every store, account deletion, export, and the records that survive deletion |
+| [03 AI acceptable use and safety](03-ai-acceptable-use-and-safety.md) | Rules that bind AI Pro before it may be enabled, including provider processing, grounding, refusal, and conversation retention |
+| [04 Educational scope](04-educational-scope.md) | Not a clinic, not medical advice, no protected health information, and what happens when someone submits it anyway |
+| [05 Support and service levels](05-support-and-service-levels.md) | Channels, hours, response targets, ownership, and what is explicitly not promised |
+| [06 Incident response](06-incident-response.md) | Severity definitions, roles, timeline, regulatory notification duties, and the postmortem requirement |
+| [07 Moderation and appeals](07-moderation-and-appeals.md) | Community standards, enforcement actions, the appeal path, and the audit trail |
+| [08 Obligation to control map](08-obligation-to-control-map.md) | Every policy obligation mapped to the control, disclosure, runbook, or issue that satisfies it |
+
+## Regulatory scope
+
+Approved on 2026-08-30. These four regimes are in scope:
+
+- **Ghana Data Protection Act, 2012 (Act 843).** The Akomapa Health Foundation
+  operates from Accra and a significant share of learners are in West Africa.
+- **United States state privacy law.** The Foundation is a US 501(c)(3) with a
+  New Haven office. CCPA/CPRA-style access, deletion, and opt-out rights are
+  honoured for any learner who asserts them, regardless of whether a threshold
+  test is met.
+- **GDPR and UK GDPR.** PRODUCT.md commits to a global and diaspora audience,
+  which includes EEA and UK learners.
+- **FERPA, as a voluntary standard.** **PENDING LEGAL REVIEW:** FERPA binds
+  educational agencies and institutions that receive US Department of Education
+  funding. Akomapa Academy is a nonprofit programme, not a funded institution,
+  so FERPA most likely does not apply as law. It is adopted here as a voluntary
+  practice standard for education records, and the applicability question is
+  referred for review. If a US university partnership later makes the Academy a
+  school official acting under an institution's control, this becomes a legal
+  obligation and this policy set must be revised before that partnership
+  starts.
+
+Where regimes disagree, the strictest requirement applies to every learner
+rather than segmenting the product by geography.
+
+## How these policies bind
+
+1. **A policy obligation without a control is not satisfied.** Policy 08 maps
+   each obligation to the code, disclosure, runbook, or issue that implements
+   it. An obligation with no control names the issue that will build one.
+2. **No unapproved assumption reaches product code.** A clause marked PENDING
+   LEGAL REVIEW may not be implemented, published, or relied on by a feature.
+3. **Policies describe what is true, not what is aspirational.** Where a
+   capability does not exist, the policy says so and names the issue. Email
+   notification, telemetry beyond platform logs, and scheduled background
+   processing do not exist today; see policy 05 and policy 08.
+4. **Changing a policy needs an approver.** Record the name and date in the
+   policy's approval block. Changing a learner-facing commitment also requires
+   updating `lib/legal-content.ts` and bumping `siteConfig.legalEffectiveDate`.
+
+## Status
+
+| Policy | Status |
+| --- | --- |
+| 01 Data protection | Approved, with marked clauses pending legal review |
+| 02 Retention and deletion | Approved, with retention minimums pending legal review |
+| 03 AI acceptable use and safety | Proposed. Gated on [#70](https://github.com/akomapahealth/akomapa-lms/issues/70); AI Pro is out of v1 scope |
+| 04 Educational scope | Approved |
+| 05 Support and service levels | Approved |
+| 06 Incident response | Approved, with notification deadlines pending legal review |
+| 07 Moderation and appeals | Approved |
+| 08 Obligation to control map | Approved |


### PR DESCRIPTION
Closes #38. Parent epic: #23. Wave 0, decisions and release definition. Release blocker.

Creates `docs/policies/`: eight internal policies plus the obligation-to-control
map. Documentation only. No product code, no schema change, and **no change to
the published `/privacy` or `/terms` pages**, which are outward-facing legal
documents and are updated separately through #119.

## Blocker status

#38 lists #36 as a blocker. #36's deliverables (PRODUCT.md, DESIGN.md,
CONTEXT.md, docs/adr/) merged into `dev` in #116 and are present at `defa52e`.
#36 remains open only because it auto-closes on the `dev` to `main` merge. The
blocker is satisfied in substance.

## What landed

| Policy | Covers |
| --- | --- |
| 01 Data protection | Regulatory scope, controller/processor roles, a data inventory of every store against its real processor, lawful bases per purpose, subject rights, transfers, children, and the public-by-design verification surface |
| 02 Retention and deletion | A named retention period for every data class, what survives deletion and why, export scope |
| 03 AI acceptable use and safety | **Proposed, not approved.** Provider processing, no-training commitment, what may never be sent, grounding and refusal, conversation retention |
| 04 Educational scope | Not a clinic, no PHI, what happens when PHI is submitted anyway, certificate limitations |
| 05 Support and service levels | Channels, hours, response targets, named escalation, and an explicit not-promised list |
| 06 Incident response | Severity by impact, roles, timeline, notification duties, blameless postmortem, and three honest capability gaps |
| 07 Moderation and appeals | Standards, proportionate actions, appeal path, audit trail |
| 08 Obligation to control map | Every obligation mapped to code, disclosure, runbook, issue, or legal review |

## Approach

Written against what is **actually true**, not what would sound good. Three
findings from the codebase shaped the policies:

- **No email provider is installed.** `UserSettings.emailOnBadgeEarned`,
  `emailOnForumReply`, and `emailOnFacultyComment` are stored preferences with
  no delivery mechanism. Policy 05 says so, and #121 resolves it.
- **No analytics or telemetry SDK exists.** No Vercel Analytics, Sentry, or
  PostHog in `package.json`. Policy 01's inventory records that the only
  telemetry is platform request and error logs.
- **No `vercel.json` and no cron.** Retention cannot be enforced automatically,
  so policy 02 states that it is enforced by hand until #118.

The published pages already carry "not a clinic" and "not medical advice"
notices and already name the processors and Ghana/GDPR rights, so this is a
gap-fill rather than a rewrite.

## Regulatory scope, as approved

Ghana Data Protection Act 2012 (Act 843), US state privacy law, GDPR and UK
GDPR, and **FERPA adopted as a voluntary standard**. On FERPA I flagged and did
not assert: it binds institutions receiving US Dept. of Education funding, and a
standalone 501(c)(3) programme most likely is not one. It is written as a
practice standard with the applicability question referred for legal review, and
policy README notes that a future US university partnership would change the
answer and require revision first.

Where regimes disagree, the strictest applies to every learner. Rights are
honoured without a jurisdiction test, because segmenting rights by geography
would be worse for the audience PRODUCT.md describes.

## What is deliberately not approved

- **Policy 03 (AI) is Proposed with a pending approver**, gated on #70. It
  exists so the privacy and retention obligations of an AI feature are written
  down before the boundaries that must satisfy them are built in Waves 1 and 2.
- **Six clauses are marked PENDING LEGAL REVIEW:** processor DPAs; EEA/UK
  transfer mechanisms; the data subject response deadline; the financial
  retention minimum and deletion grace period; breach notification deadlines;
  and AI conversation retention plus the FERPA applicability question.
  `CLAUDE.md` now forbids implementing or publishing any of them.
- **No RPO or RTO is stated anywhere**, and policy 06 forbids publishing one
  until the restore drill in #104 has actually been performed.

## Five capability gaps filed

Policy 08 marked five obligations whose control did not exist. Each is now a
filed, open issue on the v1.0.0 milestone and a child of #23:

- #117 self-service account deletion and data export
- #118 automated retention enforcement
- #119 update the published privacy and terms pages
- #120 Certificate revocation and revoked-state verification
- #121 the email notification capability gap (`ready-for-human`: it needs a
  product decision between removing the toggles and building delivery)

This also unblocks **#70**, whose only remaining blockers were #36 and #38.

## Commands executed

```
npm run validate                    # lint + typecheck, zero warnings, pass
npx commitlint --from dev --to HEAD # exit 0
node <scratchpad>/check-docs.mjs    # pass
```

The validator is a throwaway, not committed (no unit-test runner exists yet;
that is #106). It resolves every relative link and heading anchor, every
backticked repository path, every Prisma model name, and every npm script across
28 documents, and collects 75 issue references which were diffed against the
full tracker. All resolve. Build and E2E were not re-run: no code, config, or
dependency changed in this PR, and `validate` covers the whole tree.

## CI

All 11 required checks pass.

- Main workflow run: https://github.com/akomapahealth/akomapa-lms/actions/runs/33346161146
- CodeQL run: https://github.com/akomapahealth/akomapa-lms/actions/runs/33346161145
- Vercel preview: https://vercel.com/akomapa-healths-projects/akomapa-academy/7rnyn1ZRLu8yreXCFzkvvpzRFTii

No check was skipped or waived.

## Test coverage

Per #38's required coverage, this issue approves policy and produces
documentation; no product code or configuration changed, so no automated test is
owed. The verification above is the substitute: link, path, and reference
validation, plus the obligation-to-control mapping that makes each policy claim
checkable against a named control.

## Approvals

Prince Agyei Tuffour (@nanaagyei), 2026-08-30, for regulatory scope and policies
01, 02, 04, 05, 06, 07, and 08, excluding the six clauses marked PENDING LEGAL
REVIEW. Policy 03 is unapproved by design.

## Rollout and rollback

No user-visible change, no compatibility implication, no migration, no new
monitoring signal, no environment variable. Rollback is reverting the commits.

`.gitignore` gains two lines so `docs/policies/` is committable, matching the
existing `docs/agents/` and `docs/adr/` exceptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
