### PR TITLE
test: add the unit-test harness and cover core authorization and domain invariants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,36 @@ jobs:
 
       - run: npm run typecheck
 
+  unit:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      # Domain unit suite: entitlement, RBAC, completion, grading, badges,
+      # streaks, and certificate eligibility. Runs with coverage because the
+      # per-file thresholds in vitest.config.mts are the gate -- a module in the
+      # allow-list that loses coverage fails the build rather than quietly
+      # lowering an average. No database, no network: the suite stubs `fetch` to
+      # throw. Route, RLS, and transaction coverage is #107; browser journeys
+      # are #108.
+      - run: npm run test:unit:coverage
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: unit-coverage
+          path: coverage/unit
+          retention-days: 7
+
   evals:
     name: AI Evaluation Dataset
     runs-on: ubuntu-latest
@@ -100,9 +130,10 @@ jobs:
 
       # Structural validation of evals/dataset.v1.jsonl against the safety
       # rubric and thresholds. Does not call a model: the harness that executes
-      # these cases against a provider is #79. Uses the Node built-in test
-      # runner, so it adds no dependency; #106 may replace it with the shared
-      # unit-test runner when that lands.
+      # these cases against a provider is #79. Stays on the Node built-in test
+      # runner: #106 chose Vitest for the TypeScript domain suite and
+      # deliberately left these plain-JavaScript document checks alone, since
+      # porting them would add risk without adding coverage.
       - run: npm run test:evals
 
   checks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,3 +26,7 @@ This repository uses a single-context domain documentation layout. See `docs/age
 ### Delivery order
 
 Implement release work in dependency waves and keep tests inside each vertical slice. See `docs/agents/implementation-order.md`.
+
+### Testing
+
+Four suites with distinct jobs, and the rules the unit harness enforces. See `docs/agents/testing.md`. Run `npm run validate` before opening a pull request.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,10 @@ This repository uses a single-context domain documentation layout. See `docs/age
 
 Implement release work in dependency waves and keep tests inside each vertical slice. See `docs/agents/implementation-order.md`.
 
+### Testing
+
+Four suites with distinct jobs, and the rules the unit harness enforces. See `docs/agents/testing.md`. Run `npm run validate` before opening a pull request.
+
 ## Working agreement
 
 - Read the full GitHub issue, its parent epic, blockers, and linked decisions before implementation.

--- a/checks/docs-consistency.test.mjs
+++ b/checks/docs-consistency.test.mjs
@@ -106,7 +106,10 @@ test("npm scripts named in documents exist", () => {
   const errors = [];
   for (const doc of docs) {
     const src = fs.readFileSync(path.join(root, doc), "utf8");
-    for (const m of src.matchAll(/npm run ([a-z:]+)/g)) {
+    // Script names may contain digits, hyphens, and underscores. A narrower
+    // pattern silently truncates a real name (`test:e2e` -> `test:e`) and then
+    // reports the truncation as a missing script.
+    for (const m of src.matchAll(/npm run ([a-z0-9:_-]+)/g)) {
       if (!scripts.has(m[1])) errors.push(`${doc}: unknown npm script -> ${m[1]}`);
     }
   }

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -1,0 +1,84 @@
+# Testing
+
+Tests are part of a change, not a phase that follows one. Every feature or fix
+adds the coverage its own risk warrants, at the lowest layer that can catch the
+defect. The four suites below have distinct jobs; putting a test in the wrong
+one is how suites become slow and flaky.
+
+## The suites
+
+| Suite | Command | What belongs in it | Owner |
+| --- | --- | --- | --- |
+| Unit | `npm run test:unit` | Pure domain logic: entitlement, RBAC, completion, grading, badges, streaks, certificate eligibility, AI usage accounting | [#106](https://github.com/akomapahealth/akomapa-lms/issues/106) |
+| Integration | not yet available | Route handlers, RLS policies, transactions, migrations, Stripe and Clerk webhooks, against isolated PostgreSQL | [#107](https://github.com/akomapahealth/akomapa-lms/issues/107) |
+| Browser | `npm run test:e2e` | Authenticated learner, faculty, admin, commerce, and AI journeys | [#108](https://github.com/akomapahealth/akomapa-lms/issues/108) |
+| Document | `npm run test:checks`, `npm run test:evals` | Source-of-truth documents and the AI evaluation dataset | [#37](https://github.com/akomapahealth/akomapa-lms/issues/37), [#79](https://github.com/akomapahealth/akomapa-lms/issues/79) |
+
+`npm run validate` runs lint, typecheck, and every suite that does not need a
+database or a browser. Run it before opening a pull request.
+
+## The unit suite
+
+Runner: Vitest. Configuration lives in `vitest.config.mts`; shared helpers live
+in `tests/unit/support/`.
+
+```
+npm run test:unit            # once
+npm run test:unit:watch      # while working
+npm run test:unit:coverage   # with the coverage gate applied
+```
+
+### It refuses I/O on purpose
+
+`tests/unit/support/setup.ts` stubs `fetch` to throw and replaces `@/lib/db`
+with an in-memory double. A unit test that reaches for a real service fails
+with an explanatory message rather than hanging, or — far worse — passing
+because it read live state. Anything that genuinely needs a database belongs in
+the integration suite.
+
+### Determinism is enforced, not requested
+
+The clock, the timezone (`UTC`), and `Math.random` are all pinned before each
+test, and `TEACHER_ID` is cleared so a developer's shell cannot grant ADMIN and
+make an authorization test pass for the wrong reason. Use `freezeTimeAt()` from
+`tests/unit/support/time.ts` rather than constructing `new Date()` in a test.
+
+### The Prisma double fails closed
+
+Reads default to the answers an empty database would give (`null`, `[]`, `0`).
+Writes have no default and reject until a test configures them, so "this code
+writes to the database" stays an explicit assertion rather than an accident.
+
+```ts
+vi.mock("@/lib/db", async () => ({ db: (await import("./support/db")).dbMock }));
+
+dbMock.user.findUnique.mockResolvedValue(aRoleRow("FACULTY"));
+```
+
+### Coverage is an allow-list
+
+`coverage.include` in `vitest.config.mts` names individual files rather than
+sweeping the repository, and thresholds are checked **per file**. A module joins
+the list in the same pull request that brings it under test. This keeps the
+numbers meaningful: a global average across hundreds of untested files says
+nothing, and adding one well-covered module must never be able to mask a bare
+one. `lib/roles.ts` and `lib/roles-client.ts` are held at 100%.
+
+Adding a module to the list without tests will fail the build. That is the
+intent.
+
+### Write the negative case first
+
+The failure that matters is rarely "the feature did not work"; it is "the guard
+did not hold". Prefer asserting that access is denied, that a badge is not
+awarded, that a certificate is not issued. Coverage percentages prove a line
+ran, not that anything was checked — for the highest-risk invariants, corrupt
+the dependency and assert the deny-by-default contract still holds, as
+`tests/unit/roles.test.ts` does at the persistence boundary.
+
+### Characterisation tests
+
+A test may pin a defect that exists today so the issue which fixes it has a
+failing test to turn green. Label it with the owning issue and group it under a
+`known defects` describe block. Delete it in the pull request that fixes the
+defect, not before.

--- a/lib/roles.ts
+++ b/lib/roles.ts
@@ -3,8 +3,15 @@ import { db } from "@/lib/db";
 export type UserRole = "STUDENT" | "FACULTY" | "ADMIN";
 
 export async function getUserRole(userId: string): Promise<UserRole> {
-  // Fallback: check server-only env var for backward compatibility
-  if (userId === process.env.TEACHER_ID) {
+  // Fallback: check server-only env var for backward compatibility.
+  // Both sides must be non-empty. `TEACHER_ID` is `z.string().optional()`, so a
+  // blank value is valid configuration, and a blank `userId` is what an
+  // unauthenticated caller produces — comparing them would grant ADMIN to
+  // anonymous requests on any deployment that defines the variable but leaves
+  // it empty. Callers guard with `if (!userId)` today; this makes the grant
+  // safe regardless of whether a future caller remembers to.
+  const teacherId = process.env.TEACHER_ID;
+  if (teacherId && userId && userId === teacherId) {
     return "ADMIN";
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,6 +77,7 @@
         "@types/react-dom": "^18",
         "@typescript-eslint/eslint-plugin": "^8.67.0",
         "@typescript-eslint/parser": "^8.61.0",
+        "@vitest/coverage-v8": "^4.1.11",
         "autoprefixer": "^10.5.4",
         "conventional-changelog-conventionalcommits": "^8.0.0",
         "eslint": "^8",
@@ -89,7 +90,8 @@
         "semantic-release": "^24.2.9",
         "tailwindcss": "^3.4.1",
         "tsx": "^4.23.12",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^4.1.11"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -119,14 +121,40 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -136,6 +164,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@clerk/backend": {
@@ -2513,6 +2565,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.147.0.tgz",
+      "integrity": "sha512-IJ3s6ltHLp45S0bh7phkX+gJO7A1Wuz2EaqpAhb8WjqDwbzMiWKHhyyT42tskaWjEYXtHtVCPpnBJVT9+dcRLg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
       }
     },
     "node_modules/@playwright/test": {
@@ -5900,6 +5962,268 @@
         }
       }
     },
+    "node_modules/@rolldown/binding-android-arm-eabi": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.6.tgz",
+      "integrity": "sha512-b+jTcARdTiFLI6jB4a5XjTm0RWd6KcRfQj/I2356fxUZemiho9zQLxo0RtCuMDAyKcLo6cEltkgbQp6d1+sjjQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.6.tgz",
+      "integrity": "sha512-lkWU8ZJaRk9q3CIEY1Tc7vIFALp3Xw5NfGJo2hQg5oIqNgxWi1zI+IiDEK3r70BF5Dzol1tcXsnzsRc8NLhG+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.6.tgz",
+      "integrity": "sha512-dgR56NYnvAszm7Ob1B2/Vn0e8bUQYZH2UjVaMMtMVOCKFSfjhfLmuA/9+O+F+ajUdG6B/bSssrKW6JJYASa8jA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.6.tgz",
+      "integrity": "sha512-vpVxFvUCFioJqug7OTvqptkc4yb8UX0AwfDmJpaR/0sWz+BUmqSVAf7c8JkUgnN8YLspb4a/N6NhTyMAmdyQ7Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.6.tgz",
+      "integrity": "sha512-h1wG6Y6K3JlRswxsI64qQJqBAy4vrLuHgRbc8CZMGSWTOFRY6ghMApM1NKzB2I0n5xV1fjkE18SuVl2QpLeNpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.6.tgz",
+      "integrity": "sha512-tbCiqub0q2MVWJKgF5PoAlNWCtQydiOYSLIkd8sByqK/6MMYLJRcSXSYodqYtd0O+Fw7QaVmKKlS4oL94YRZ0w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.6.tgz",
+      "integrity": "sha512-oxK9+baEBPhZG5HB4URY+uU04zJWeZlH6Tb9rB5DK4DF9XR1uXNLXt5Q5ZsugTKayNCNLhkcwz/ye74hRI98dg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.6.tgz",
+      "integrity": "sha512-muWCk27FVBEZtv0MsK8gnfSmgczA8KQ0uRVJbTABKhkRfQc38aUrcb7fhi3BNiyseFmgcRsoMfQsSNJ+DbZdSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.6.tgz",
+      "integrity": "sha512-eWDoSfU7Co2qj3vgB3Dt4lj1mG6CoWbcJQkRMP3XJplyCMtuaq3LHvPFjS9QIPvMGWVadJC04Xiy0IdcVPtnwQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.6.tgz",
+      "integrity": "sha512-2bWNjRSIayvupRKxXUY2tWG9fYdoUlTqWywHRvE8Eq3GvuQ+f2HeIkve697fIt+IQs/PV8yFsdWuhp1aJ1PdnA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.6.tgz",
+      "integrity": "sha512-KekI0gS0wLxe1UBSQSjenBVwou/JkcQPDzBPICGZjxUv9k3RteHDPBQaiOicZUFKRIH2wKEimGwVpnJsbPzu7w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.6.tgz",
+      "integrity": "sha512-TvtPnfVr+HtyGiDmPK4VWmlNm7QhNNAcK5Q9A7aOXsI8545yCyaoMaicXrFZ72JzeYjaUVk7yT243zT0jzjFKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.6.tgz",
+      "integrity": "sha512-iOo0VEay2XFhaCcH0sps5XIimkSuOnNaZrf6+ZkoSOQBJPKNU48RkmJv0/lSpipexu5P+ouFgafe5IGr/DiQfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.6.tgz",
+      "integrity": "sha512-y5NTmmasMS455JlOCO4ZM9krIchv3Mvm1crL1iUPGOPgEzSkves9n0SdC5Sjz6+qWDFhd8/JpfWMH8NSWNHe+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.6.tgz",
+      "integrity": "sha512-np8iZSLfXlAD4kWhiyq/u0Yt8oZDtRQ8lGhQaCXo2rl37KNjeU0GjJuwr4P3oeZ++ROfofsKNBqR5LTO8aXyWQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -6232,6 +6556,17 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/conventional-commits-parser": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@types/conventional-commits-parser/-/conventional-commits-parser-5.0.2.tgz",
@@ -6334,6 +6669,20 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/geojson": {
@@ -7248,6 +7597,157 @@
         "node": ">=12"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.11.tgz",
+      "integrity": "sha512-8MVGEFnJIcdGjcbfKmeq8z0pZHH0JlVtoVZH9Q/qwUp6wyFnEJUBMrw9DCaj+ra3vShGmhavjalMIhPNxZAUcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.11",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.11",
+        "vitest": "4.1.11"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.11",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.11",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -7628,10 +8128,39 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -8089,6 +8618,16 @@
       "license": "BSD-3-Clause",
       "peerDependencies": {
         "react": ">=17.0.0"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -8688,6 +9227,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -9209,8 +9755,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -9650,6 +10196,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -10222,6 +10775,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -10298,6 +10861,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/exsolve": {
@@ -11328,6 +11901,13 @@
       "integrity": "sha512-LgOWAkrN0rFaQpfdWBQlv/VhkOxb5AsBjk6NQVx4yEzWS923T07X0M1Y0VNko2H52HeSpZrZNNMJ0aFqsdVzQg==",
       "license": "ISC"
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -12097,6 +12677,45 @@
         "node": "^18.17 || >=20.6.1"
       }
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -12340,6 +12959,267 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/lilconfig": {
@@ -12640,6 +13520,28 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.4.tgz",
+      "integrity": "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "source-map-js": "^1.2.1"
+      }
+    },
     "node_modules/make-asynchronous": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/make-asynchronous/-/make-asynchronous-1.1.0.tgz",
@@ -12666,6 +13568,22 @@
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -15954,6 +16872,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/ohash": {
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.12.tgz",
@@ -17712,6 +18644,40 @@
       "devOptional": true,
       "license": "Unlicense"
     },
+    "node_modules/rolldown": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.6.tgz",
+      "integrity": "sha512-vMM4q3aixf46GiF1Kok8jDPFsEpXgFWGjUHXNkNHNm+Y2adXAG2dbX91jkti3i0ZRsOlcmbuzAz1poObSHCmUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.147.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm-eabi": "1.2.6",
+        "@rolldown/binding-android-arm64": "1.2.6",
+        "@rolldown/binding-darwin-arm64": "1.2.6",
+        "@rolldown/binding-darwin-x64": "1.2.6",
+        "@rolldown/binding-freebsd-x64": "1.2.6",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.6",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.6",
+        "@rolldown/binding-linux-arm64-musl": "1.2.6",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.6",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.6",
+        "@rolldown/binding-linux-x64-gnu": "1.2.6",
+        "@rolldown/binding-linux-x64-musl": "1.2.6",
+        "@rolldown/binding-openharmony-arm64": "1.2.6",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.6",
+        "@rolldown/binding-win32-x64-msvc": "1.2.6"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -18175,6 +19141,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -18410,6 +19383,13 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
     },
@@ -19037,6 +20017,13 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
@@ -19048,9 +20035,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -19090,6 +20077,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -19655,6 +20652,84 @@
         "d3-timer": "^3.0.1"
       }
     },
+    "node_modules/vite": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+      "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.26",
+        "rolldown": "~1.2.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0 || ^0.5.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vite-compatible-readable-stream": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/vite-compatible-readable-stream/-/vite-compatible-readable-stream-3.6.1.tgz",
@@ -19668,6 +20743,158 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vite/node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest/node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
@@ -19804,6 +21031,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "typecheck": "tsc --noEmit",
     "test:evals": "node --test evals/*.test.mjs",
     "test:checks": "node --test checks/*.test.mjs",
-    "validate": "npm run lint && npm run typecheck && npm run test:evals && npm run test:checks",
+    "test:unit": "vitest run",
+    "test:unit:watch": "vitest",
+    "test:unit:coverage": "vitest run --coverage",
+    "validate": "npm run lint && npm run typecheck && npm run test:unit && npm run test:evals && npm run test:checks",
     "postinstall": "prisma generate",
     "db:migrate": "prisma migrate dev",
     "db:studio": "prisma studio",
@@ -89,6 +92,7 @@
     "@types/react-dom": "^18",
     "@typescript-eslint/eslint-plugin": "^8.67.0",
     "@typescript-eslint/parser": "^8.61.0",
+    "@vitest/coverage-v8": "^4.1.11",
     "autoprefixer": "^10.5.4",
     "conventional-changelog-conventionalcommits": "^8.0.0",
     "eslint": "^8",
@@ -101,7 +105,8 @@
     "semantic-release": "^24.2.9",
     "tailwindcss": "^3.4.1",
     "tsx": "^4.23.12",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.1.11"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/tests/unit/badge-service.test.ts
+++ b/tests/unit/badge-service.test.ts
@@ -1,0 +1,467 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { aBadgeWithCriteria } from "./support/builders";
+import { dbMock } from "./support/db";
+
+vi.mock("@/lib/db", async () => ({
+  db: (await import("./support/db")).dbMock,
+}));
+
+const { evaluateBadges } = await import("@/lib/badge-service");
+type BadgeEvent = Parameters<typeof evaluateBadges>[1];
+
+/**
+ * Badges are cheap to award and expensive to retract: a learner who sees a
+ * badge appear and disappear loses trust in every other number on the page.
+ * The rules that matter are therefore "award exactly once" and "award only on
+ * the matching event", and both are covered below alongside the thresholds.
+ *
+ * Related work: #83 makes awarding idempotent and event-driven.
+ */
+beforeEach(() => {
+  dbMock.userBadge.createMany.mockResolvedValue({ count: 1 });
+});
+
+/** Offers a single unearned badge and reports whether the event earned it. */
+async function earns(
+  criteria: Record<string, unknown>,
+  event: BadgeEvent
+): Promise<boolean> {
+  dbMock.badge.findMany.mockResolvedValue([aBadgeWithCriteria(criteria)]);
+  const awarded = await evaluateBadges("user_1", event);
+  return awarded.length === 1;
+}
+
+describe("evaluateBadges", () => {
+  it("awards nothing when no badges are defined", async () => {
+    dbMock.badge.findMany.mockResolvedValue([]);
+
+    await expect(evaluateBadges("user_1", { type: "post_created", postId: "p1" }))
+      .resolves.toEqual([]);
+    expect(dbMock.userBadge.createMany).not.toHaveBeenCalled();
+  });
+
+  it("never re-awards a badge the learner already holds", async () => {
+    const badge = aBadgeWithCriteria({ type: "topics_completed", count: 1 });
+    dbMock.badge.findMany.mockResolvedValue([badge]);
+    dbMock.userBadge.findMany.mockResolvedValue([{ badgeId: badge.id }]);
+    dbMock.userProgress.count.mockResolvedValue(999);
+
+    await expect(
+      evaluateBadges("user_1", { type: "topic_completed", topicId: "t1" })
+    ).resolves.toEqual([]);
+    expect(dbMock.userBadge.createMany).not.toHaveBeenCalled();
+  });
+
+  it("persists newly earned badges with skipDuplicates so a concurrent award cannot fail the request", async () => {
+    dbMock.userProgress.count.mockResolvedValue(5);
+    dbMock.badge.findMany.mockResolvedValue([
+      aBadgeWithCriteria({ type: "topics_completed", count: 1 }, { id: "badge_a" }),
+      aBadgeWithCriteria({ type: "topics_completed", count: 5 }, { id: "badge_b" }),
+    ]);
+
+    const awarded = await evaluateBadges("user_1", {
+      type: "topic_completed",
+      topicId: "t1",
+    });
+
+    expect(awarded.map((b) => b.id)).toEqual(["badge_a", "badge_b"]);
+    expect(dbMock.userBadge.createMany).toHaveBeenCalledWith({
+      data: [
+        { userId: "user_1", badgeId: "badge_a" },
+        { userId: "user_1", badgeId: "badge_b" },
+      ],
+      skipDuplicates: true,
+    });
+  });
+
+  it("ignores criteria types it does not recognise", async () => {
+    expect(
+      await earns({ type: "logged_in_on_a_tuesday", count: 1 }, {
+        type: "post_created",
+        postId: "p1",
+      })
+    ).toBe(false);
+  });
+});
+
+describe("criteria are bound to their triggering event", () => {
+  /**
+   * Every rule checks the event type first. Without that guard, completing a
+   * Topic could award a community badge whose counter happened to be high
+   * enough, which is how badge systems start awarding things at random.
+   */
+  const mismatches: Array<[string, Record<string, unknown>, BadgeEvent]> = [
+    ["topics_completed", { type: "topics_completed", count: 1 }, { type: "post_created", postId: "p1" }],
+    ["modules_completed", { type: "modules_completed", count: 1 }, { type: "topic_completed", topicId: "t1" }],
+    ["courses_completed", { type: "courses_completed", count: 1 }, { type: "module_completed", moduleId: "m1" }],
+    ["quiz_score", { type: "quiz_score", score: 50 }, { type: "topic_completed", topicId: "t1" }],
+    ["streak_days", { type: "streak_days", count: 1 }, { type: "topic_completed", topicId: "t1" }],
+    ["posts_created", { type: "posts_created", count: 1 }, { type: "comment_created", commentId: "c1" }],
+    ["comments_created", { type: "comments_created", count: 1 }, { type: "post_created", postId: "p1" }],
+  ];
+
+  for (const [name, criteria, wrongEvent] of mismatches) {
+    it(`does not award ${name} on a ${wrongEvent.type} event`, async () => {
+      dbMock.userProgress.count.mockResolvedValue(999);
+      dbMock.forumPost.count.mockResolvedValue(999);
+      dbMock.forumComment.count.mockResolvedValue(999);
+      dbMock.enrollment.count.mockResolvedValue(999);
+
+      expect(await earns(criteria, wrongEvent)).toBe(false);
+    });
+  }
+});
+
+describe("counting thresholds", () => {
+  const event: BadgeEvent = { type: "topic_completed", topicId: "t1" };
+
+  it("awards at the threshold and above, but not below", async () => {
+    for (const [completed, expected] of [
+      [4, false],
+      [5, true],
+      [6, true],
+    ] as const) {
+      dbMock.userProgress.count.mockResolvedValue(completed);
+      expect(await earns({ type: "topics_completed", count: 5 }, event)).toBe(expected);
+    }
+  });
+
+  it("falls back to a threshold of 1 when the criteria omit a count", async () => {
+    dbMock.userProgress.count.mockResolvedValue(1);
+    expect(await earns({ type: "topics_completed" }, event)).toBe(true);
+
+    dbMock.userProgress.count.mockResolvedValue(0);
+    expect(await earns({ type: "topics_completed" }, event)).toBe(false);
+  });
+
+  it("counts only completed progress rows for the requesting learner", async () => {
+    dbMock.userProgress.count.mockResolvedValue(1);
+    await earns({ type: "topics_completed", count: 1 }, event);
+
+    expect(dbMock.userProgress.count).toHaveBeenCalledWith({
+      where: { userId: "user_1", isCompleted: true },
+    });
+  });
+
+  it("counts completed Courses from Enrollment, the canonical entitlement", async () => {
+    dbMock.enrollment.count.mockResolvedValue(3);
+    expect(
+      await earns({ type: "courses_completed", count: 3 }, {
+        type: "course_completed",
+        courseId: "course_1",
+      })
+    ).toBe(true);
+    expect(dbMock.enrollment.count).toHaveBeenCalledWith({
+      where: { userId: "user_1", status: "COMPLETED" },
+    });
+  });
+});
+
+describe("quiz score criteria", () => {
+  const attempt = (score: number, preTestScore?: number): BadgeEvent => ({
+    type: "quiz_completed",
+    quizId: "quiz_1",
+    score,
+    preTestScore,
+  });
+
+  it("awards at the exact passing score and above", async () => {
+    for (const [score, expected] of [
+      [79, false],
+      [80, true],
+      [100, true],
+    ] as const) {
+      expect(await earns({ type: "quiz_score", score: 80 }, attempt(score))).toBe(expected);
+    }
+  });
+
+  it("demands a perfect score when the criteria omit one", async () => {
+    expect(await earns({ type: "quiz_score" }, attempt(99))).toBe(false);
+    expect(await earns({ type: "quiz_score" }, attempt(100))).toBe(true);
+  });
+
+  it("awards improvement only when a pre-test score exists", async () => {
+    // A missing pre-test must not be read as a zero, which would turn any
+    // post-test result into a large improvement.
+    expect(
+      await earns({ type: "score_improvement", minImprovement: 20 }, attempt(90))
+    ).toBe(false);
+    expect(
+      await earns({ type: "score_improvement", minImprovement: 20 }, attempt(90, 70))
+    ).toBe(true);
+  });
+
+  it("measures improvement at the threshold, and ignores a decline", async () => {
+    for (const [pre, post, expected] of [
+      [70, 89, false],
+      [70, 90, true],
+      [90, 70, false],
+      [70, 70, false],
+    ] as const) {
+      expect(
+        await earns({ type: "score_improvement", minImprovement: 20 }, attempt(post, pre))
+      ).toBe(expected);
+    }
+  });
+});
+
+describe("streak criteria", () => {
+  it("awards at the streak threshold and above", async () => {
+    for (const [days, expected] of [
+      [6, false],
+      [7, true],
+      [8, true],
+    ] as const) {
+      expect(
+        await earns({ type: "streak_days", count: 7 }, {
+          type: "streak_updated",
+          currentStreak: days,
+        })
+      ).toBe(expected);
+    }
+  });
+
+  it("defaults to a seven-day streak when the criteria omit a count", async () => {
+    expect(
+      await earns({ type: "streak_days" }, { type: "streak_updated", currentStreak: 7 })
+    ).toBe(true);
+    expect(
+      await earns({ type: "streak_days" }, { type: "streak_updated", currentStreak: 6 })
+    ).toBe(false);
+  });
+});
+
+describe("module and category completion", () => {
+  it("requires every published Topic in a Module to be complete", async () => {
+    dbMock.module.findMany.mockResolvedValue([
+      { id: "module_1", isPublished: true, topics: [{ id: "t1" }, { id: "t2" }] },
+    ]);
+    dbMock.userProgress.count.mockResolvedValue(1);
+
+    expect(
+      await earns({ type: "modules_completed", count: 1 }, {
+        type: "module_completed",
+        moduleId: "module_1",
+      })
+    ).toBe(false);
+
+    dbMock.userProgress.count.mockResolvedValue(2);
+    expect(
+      await earns({ type: "modules_completed", count: 1 }, {
+        type: "module_completed",
+        moduleId: "module_1",
+      })
+    ).toBe(true);
+  });
+
+  it("does not count an empty Module as completed", async () => {
+    // A Module with no published Topics is vacuously "complete" under a naive
+    // rule. #59 owns the equivalent rule for Courses.
+    dbMock.module.findMany.mockResolvedValue([
+      { id: "module_1", isPublished: true, topics: [] },
+    ]);
+
+    expect(
+      await earns({ type: "modules_completed", count: 1 }, {
+        type: "module_completed",
+        moduleId: "module_1",
+      })
+    ).toBe(false);
+  });
+
+  it("does not award a category badge when the learner owns no Course in it", async () => {
+    dbMock.course.findMany.mockResolvedValue([]);
+
+    expect(
+      await earns({ type: "category_completed", category: "Ethics" }, {
+        type: "course_completed",
+        courseId: "course_1",
+      })
+    ).toBe(false);
+  });
+
+  it("awards the category badge once every Module in it is complete", async () => {
+    dbMock.course.findMany.mockResolvedValue([
+      {
+        id: "course_1",
+        modules: [
+          { id: "module_1", isPublished: true, topics: [{ id: "t1" }] },
+          // An empty Module is skipped rather than blocking the award.
+          { id: "module_2", isPublished: true, topics: [] },
+        ],
+      },
+    ]);
+    dbMock.userProgress.count.mockResolvedValue(1);
+
+    expect(
+      await earns({ type: "category_completed", category: "Ethics" }, {
+        type: "module_completed",
+        moduleId: "module_1",
+      })
+    ).toBe(true);
+  });
+
+  it("requires every Module of every owned Course in the category", async () => {
+    dbMock.course.findMany.mockResolvedValue([
+      {
+        id: "course_1",
+        modules: [
+          { id: "module_1", isPublished: true, topics: [{ id: "t1" }] },
+          { id: "module_2", isPublished: true, topics: [{ id: "t2" }, { id: "t3" }] },
+        ],
+      },
+    ]);
+    dbMock.userProgress.count.mockResolvedValue(1);
+
+    expect(
+      await earns({ type: "category_completed", category: "Ethics" }, {
+        type: "course_completed",
+        courseId: "course_1",
+      })
+    ).toBe(false);
+  });
+});
+
+describe("community criteria", () => {
+  it("counts a learner's own posts against the threshold", async () => {
+    const event: BadgeEvent = { type: "post_created", postId: "p1" };
+
+    for (const [posts, expected] of [
+      [4, false],
+      [5, true],
+    ] as const) {
+      dbMock.forumPost.count.mockResolvedValue(posts);
+      expect(await earns({ type: "posts_created", count: 5 }, event)).toBe(expected);
+    }
+
+    expect(dbMock.forumPost.count).toHaveBeenCalledWith({ where: { userId: "user_1" } });
+  });
+
+  it("defaults the post threshold to five", async () => {
+    const event: BadgeEvent = { type: "post_created", postId: "p1" };
+
+    dbMock.forumPost.count.mockResolvedValue(5);
+    expect(await earns({ type: "posts_created" }, event)).toBe(true);
+    dbMock.forumPost.count.mockResolvedValue(4);
+    expect(await earns({ type: "posts_created" }, event)).toBe(false);
+  });
+
+  it("counts a learner's own comments against the threshold", async () => {
+    const event: BadgeEvent = { type: "comment_created", commentId: "c1" };
+
+    for (const [comments, expected] of [
+      [9, false],
+      [10, true],
+    ] as const) {
+      dbMock.forumComment.count.mockResolvedValue(comments);
+      expect(await earns({ type: "comments_created" }, event)).toBe(expected);
+    }
+
+    expect(dbMock.forumComment.count).toHaveBeenCalledWith({ where: { userId: "user_1" } });
+  });
+
+  it("counts likes received on the learner's posts, not likes they gave", async () => {
+    dbMock.postLike.count.mockResolvedValue(50);
+
+    expect(
+      await earns({ type: "post_likes_received" }, { type: "post_created", postId: "p1" })
+    ).toBe(true);
+
+    // `post: { userId }` scopes to likes *on* the learner's posts. Scoping to
+    // `userId` directly would count likes the learner handed out.
+    expect(dbMock.postLike.count).toHaveBeenCalledWith({
+      where: { post: { userId: "user_1" } },
+    });
+  });
+
+  it("awards likes received on either a post or a comment event, and denies below the threshold", async () => {
+    dbMock.postLike.count.mockResolvedValue(49);
+    expect(
+      await earns({ type: "post_likes_received", count: 50 }, { type: "post_created", postId: "p1" })
+    ).toBe(false);
+
+    dbMock.postLike.count.mockResolvedValue(50);
+    expect(
+      await earns({ type: "post_likes_received", count: 50 }, {
+        type: "comment_created",
+        commentId: "c1",
+      })
+    ).toBe(true);
+  });
+
+  it("does not award likes received on an unrelated event", async () => {
+    dbMock.postLike.count.mockResolvedValue(999);
+    expect(
+      await earns({ type: "post_likes_received" }, { type: "topic_completed", topicId: "t1" })
+    ).toBe(false);
+  });
+});
+
+describe("all_quizzes_passed", () => {
+  it("denies when the triggering Quiz belongs to no Course", async () => {
+    dbMock.quiz.findUnique.mockResolvedValue({ courseId: null });
+
+    expect(
+      await earns({ type: "all_quizzes_passed" }, {
+        type: "quiz_completed",
+        quizId: "quiz_1",
+        score: 100,
+      })
+    ).toBe(false);
+  });
+
+  it("denies when any published Quiz has no completed attempt", async () => {
+    dbMock.quiz.findUnique.mockResolvedValue({ courseId: "course_1" });
+    dbMock.quiz.findMany.mockResolvedValue([
+      { id: "quiz_1", passingScore: 70 },
+      { id: "quiz_2", passingScore: 70 },
+    ]);
+    dbMock.quizAttempt.findFirst
+      .mockResolvedValueOnce({ score: 90 })
+      .mockResolvedValueOnce(null);
+
+    expect(
+      await earns({ type: "all_quizzes_passed" }, {
+        type: "quiz_completed",
+        quizId: "quiz_1",
+        score: 90,
+      })
+    ).toBe(false);
+  });
+
+  it("denies at one point below the passing score and awards at it", async () => {
+    dbMock.quiz.findUnique.mockResolvedValue({ courseId: "course_1" });
+    dbMock.quiz.findMany.mockResolvedValue([{ id: "quiz_1", passingScore: 70 }]);
+
+    for (const [score, expected] of [
+      [69, false],
+      [70, true],
+    ] as const) {
+      dbMock.quizAttempt.findFirst.mockResolvedValue({ score });
+      expect(
+        await earns({ type: "all_quizzes_passed" }, {
+          type: "quiz_completed",
+          quizId: "quiz_1",
+          score,
+        })
+      ).toBe(expected);
+    }
+  });
+
+  it("treats a null score as failing rather than as zero-passing", async () => {
+    dbMock.quiz.findUnique.mockResolvedValue({ courseId: "course_1" });
+    dbMock.quiz.findMany.mockResolvedValue([{ id: "quiz_1", passingScore: 0 }]);
+    dbMock.quizAttempt.findFirst.mockResolvedValue({ score: null });
+
+    // passingScore 0 makes `0 >= 0` true, so this documents that a graded-null
+    // attempt still satisfies a zero threshold; any non-zero threshold denies.
+    expect(
+      await earns({ type: "all_quizzes_passed" }, {
+        type: "quiz_completed",
+        quizId: "quiz_1",
+        score: 0,
+      })
+    ).toBe(true);
+  });
+});

--- a/tests/unit/certificate-service.test.ts
+++ b/tests/unit/certificate-service.test.ts
@@ -1,0 +1,287 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { aCertificate, anEnrollment } from "./support/builders";
+import { dbMock } from "./support/db";
+import { freezeTimeAt } from "./support/time";
+
+vi.mock("@/lib/db", async () => ({
+  db: (await import("./support/db")).dbMock,
+}));
+
+// The PDF renderer is slow, native, and irrelevant to the rules under test.
+// `vi.hoisted` runs before the hoisted `vi.mock` factories, so the spy exists
+// by the time the factory below closes over it.
+const { renderToBuffer } = vi.hoisted(() => ({
+  renderToBuffer: vi.fn(async (_element: { props: Record<string, unknown> }) =>
+    Buffer.from("pdf-bytes")
+  ),
+}));
+vi.mock("@react-pdf/renderer", () => ({ renderToBuffer }));
+vi.mock("@/lib/certificate-template", () => ({ CertificateTemplate: () => null }));
+
+/** The props the certificate template was rendered with, or a clear failure. */
+function renderedProps(): Record<string, unknown> {
+  const call = renderToBuffer.mock.calls[0];
+  if (!call) throw new Error("the certificate was never rendered");
+  return call[0].props;
+}
+
+const { generateCertificate } = await import("@/lib/certificate-service");
+
+/**
+ * A certificate is the product's only externally verifiable claim, so the rule
+ * that matters most is the negative one: it must be impossible to obtain
+ * without a COMPLETED Enrollment. Issuance must also be idempotent, because a
+ * learner who refreshes the page must not mint a second certificate number.
+ *
+ * Related work: #84 moves storage to object storage and adds atomic issuance,
+ * QR verification, and revocation; #120 adds revoked-state verification.
+ */
+const EXPECTED_PDF_URL = `data:application/pdf;base64,${Buffer.from("pdf-bytes").toString("base64")}`;
+
+beforeEach(() => {
+  freezeTimeAt("2026-06-15T09:00:00.000Z");
+  dbMock.certificate.upsert.mockResolvedValue(aCertificate());
+  dbMock.course.findUnique.mockResolvedValue({ title: "Research Ethics", quizzes: [] });
+});
+
+describe("eligibility", () => {
+  it("refuses to issue without a COMPLETED Enrollment", async () => {
+    dbMock.enrollment.findFirst.mockResolvedValue(null);
+
+    await expect(generateCertificate("user_1", "course_1")).resolves.toBeNull();
+    expect(renderToBuffer).not.toHaveBeenCalled();
+    expect(dbMock.certificate.upsert).not.toHaveBeenCalled();
+  });
+
+  it("checks completion for the exact learner and Course pair", async () => {
+    dbMock.enrollment.findFirst.mockResolvedValue(anEnrollment({ status: "COMPLETED" }));
+
+    await generateCertificate("user_9", "course_9");
+
+    expect(dbMock.enrollment.findFirst).toHaveBeenCalledWith({
+      where: { userId: "user_9", courseId: "course_9", status: "COMPLETED" },
+    });
+  });
+
+  it("refuses when the Course no longer exists", async () => {
+    dbMock.enrollment.findFirst.mockResolvedValue(anEnrollment({ status: "COMPLETED" }));
+    dbMock.course.findUnique.mockResolvedValue(null);
+
+    await expect(generateCertificate("user_1", "course_1")).resolves.toBeNull();
+    expect(dbMock.certificate.upsert).not.toHaveBeenCalled();
+  });
+
+  it("refuses to regenerate a half-written certificate without completion", async () => {
+    // A row exists but its PDF never persisted. Recovery must still re-check
+    // entitlement rather than trusting the orphaned row as proof of completion.
+    dbMock.certificate.findUnique.mockResolvedValue(aCertificate({ pdfUrl: null }));
+    dbMock.enrollment.findFirst.mockResolvedValue(null);
+
+    await expect(generateCertificate("user_1", "course_1")).resolves.toBeNull();
+  });
+});
+
+describe("idempotency", () => {
+  it("returns the existing certificate without re-rendering", async () => {
+    dbMock.certificate.findUnique.mockResolvedValue(
+      aCertificate({ certificateNumber: "GHELP-2026-00042", pdfUrl: "data:application/pdf;base64,AAAA" })
+    );
+
+    await expect(generateCertificate("user_1", "course_1")).resolves.toEqual({
+      certificateNumber: "GHELP-2026-00042",
+      pdfUrl: "data:application/pdf;base64,AAAA",
+    });
+    expect(renderToBuffer).not.toHaveBeenCalled();
+    expect(dbMock.enrollment.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("reuses the original number when repairing a certificate with no PDF", async () => {
+    dbMock.certificate.findUnique.mockResolvedValue(
+      aCertificate({ certificateNumber: "GHELP-2026-00042", pdfUrl: null })
+    );
+    dbMock.enrollment.findFirst.mockResolvedValue(anEnrollment({ status: "COMPLETED" }));
+
+    const result = await generateCertificate("user_1", "course_1");
+
+    // Allocating a fresh number here would leave the learner holding two
+    // identifiers for one achievement.
+    expect(result?.certificateNumber).toBe("GHELP-2026-00042");
+    expect(dbMock.certificate.findFirst).not.toHaveBeenCalled();
+  });
+});
+
+describe("certificate numbering", () => {
+  beforeEach(() => {
+    dbMock.enrollment.findFirst.mockResolvedValue(anEnrollment({ status: "COMPLETED" }));
+  });
+
+  it("starts at one for the first certificate of the year", async () => {
+    dbMock.certificate.findFirst.mockResolvedValue(null);
+
+    const result = await generateCertificate("user_1", "course_1");
+
+    expect(result?.certificateNumber).toBe("GHELP-2026-00001");
+    expect(dbMock.certificate.findFirst).toHaveBeenCalledWith({
+      where: { certificateNumber: { startsWith: "GHELP-2026-" } },
+      orderBy: { certificateNumber: "desc" },
+      select: { certificateNumber: true },
+    });
+  });
+
+  it("continues from the highest number already issued", async () => {
+    dbMock.certificate.findFirst.mockResolvedValue({ certificateNumber: "GHELP-2026-00007" });
+
+    const result = await generateCertificate("user_1", "course_1");
+
+    expect(result?.certificateNumber).toBe("GHELP-2026-00008");
+  });
+
+  it("keeps five-digit padding as numbers grow", async () => {
+    dbMock.certificate.findFirst.mockResolvedValue({ certificateNumber: "GHELP-2026-00999" });
+
+    await expect(generateCertificate("user_1", "course_1")).resolves.toMatchObject({
+      certificateNumber: "GHELP-2026-01000",
+    });
+  });
+
+  it("scopes the sequence to the current year", async () => {
+    freezeTimeAt("2027-01-01T00:00:00.000Z");
+    dbMock.certificate.findFirst.mockResolvedValue(null);
+
+    await expect(generateCertificate("user_1", "course_1")).resolves.toMatchObject({
+      certificateNumber: "GHELP-2027-00001",
+    });
+  });
+
+  it("restarts at one rather than emitting NaN when the latest number is malformed", async () => {
+    dbMock.certificate.findFirst.mockResolvedValue({ certificateNumber: "GHELP-2026-legacy" });
+
+    await expect(generateCertificate("user_1", "course_1")).resolves.toMatchObject({
+      certificateNumber: "GHELP-2026-00001",
+    });
+  });
+});
+
+describe("pre-test and post-test scores", () => {
+  beforeEach(() => {
+    dbMock.enrollment.findFirst.mockResolvedValue(anEnrollment({ status: "COMPLETED" }));
+    dbMock.certificate.findFirst.mockResolvedValue(null);
+  });
+
+  async function propsAfterIssuing(): Promise<Record<string, unknown>> {
+    await generateCertificate("user_1", "course_1");
+    return renderedProps();
+  }
+
+  it("converts raw points to a rounded percentage", async () => {
+    dbMock.course.findUnique.mockResolvedValue({
+      title: "Research Ethics",
+      quizzes: [
+        { type: "PRE_TEST", attempts: [{ score: 5, totalPoints: 20 }] },
+        { type: "POST_TEST", attempts: [{ score: 17, totalPoints: 20 }] },
+      ],
+    });
+
+    expect(await propsAfterIssuing()).toMatchObject({ preTestScore: 25, postTestScore: 85 });
+  });
+
+  it("rounds halves upward consistently", async () => {
+    dbMock.course.findUnique.mockResolvedValue({
+      title: "Research Ethics",
+      quizzes: [{ type: "PRE_TEST", attempts: [{ score: 1, totalPoints: 8 }] }],
+    });
+
+    // 12.5 rounds to 13, not 12.
+    expect(await propsAfterIssuing()).toMatchObject({ preTestScore: 13 });
+  });
+
+  it("reports no score when the learner never attempted the quiz", async () => {
+    dbMock.course.findUnique.mockResolvedValue({
+      title: "Research Ethics",
+      quizzes: [
+        { type: "PRE_TEST", attempts: [] },
+        { type: "POST_TEST", attempts: [] },
+      ],
+    });
+
+    expect(await propsAfterIssuing()).toMatchObject({ preTestScore: null, postTestScore: null });
+  });
+
+  it("reports no score rather than dividing by a zero or null total", async () => {
+    dbMock.course.findUnique.mockResolvedValue({
+      title: "Research Ethics",
+      quizzes: [
+        { type: "PRE_TEST", attempts: [{ score: 10, totalPoints: 0 }] },
+        { type: "POST_TEST", attempts: [{ score: 10, totalPoints: null }] },
+      ],
+    });
+
+    expect(await propsAfterIssuing()).toMatchObject({ preTestScore: null, postTestScore: null });
+  });
+
+  it("treats an ungraded attempt as zero rather than failing", async () => {
+    dbMock.course.findUnique.mockResolvedValue({
+      title: "Research Ethics",
+      quizzes: [{ type: "PRE_TEST", attempts: [{ score: null, totalPoints: 20 }] }],
+    });
+
+    expect(await propsAfterIssuing()).toMatchObject({ preTestScore: 0 });
+  });
+});
+
+describe("the rendered certificate", () => {
+  beforeEach(() => {
+    dbMock.enrollment.findFirst.mockResolvedValue(anEnrollment({ status: "COMPLETED" }));
+    dbMock.certificate.findFirst.mockResolvedValue(null);
+  });
+
+  it("names the learner and formats the issue date unambiguously", async () => {
+    dbMock.user.findUnique.mockResolvedValue({ firstName: "Ama", lastName: "Mensah" });
+
+    await generateCertificate("user_1", "course_1");
+
+    expect(renderedProps()).toMatchObject({
+      studentName: "Ama Mensah",
+      courseTitle: "Research Ethics",
+      issuedDate: "15 June 2026",
+    });
+  });
+
+  it("falls back to a placeholder rather than printing 'undefined' as a name", async () => {
+    for (const user of [null, {}, { firstName: null, lastName: null }]) {
+      renderToBuffer.mockClear();
+      dbMock.user.findUnique.mockResolvedValue(user);
+
+      await generateCertificate("user_1", "course_1");
+
+      expect(renderedProps().studentName).toBe("Student");
+    }
+  });
+
+  it("uses whichever name part exists", async () => {
+    dbMock.user.findUnique.mockResolvedValue({ firstName: "Ama", lastName: null });
+
+    await generateCertificate("user_1", "course_1");
+
+    expect(renderedProps().studentName).toBe("Ama");
+  });
+
+  it("persists the certificate against the learner and Course pair", async () => {
+    await expect(generateCertificate("user_1", "course_1")).resolves.toEqual({
+      certificateNumber: "GHELP-2026-00001",
+      pdfUrl: EXPECTED_PDF_URL,
+    });
+
+    expect(dbMock.certificate.upsert).toHaveBeenCalledWith({
+      where: { userId_courseId: { userId: "user_1", courseId: "course_1" } },
+      create: {
+        userId: "user_1",
+        courseId: "course_1",
+        certificateNumber: "GHELP-2026-00001",
+        pdfUrl: EXPECTED_PDF_URL,
+      },
+      update: { pdfUrl: EXPECTED_PDF_URL },
+    });
+  });
+});

--- a/tests/unit/roles-client.test.ts
+++ b/tests/unit/roles-client.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { isAdminClient, isFacultyClient } from "@/lib/roles-client";
+
+/**
+ * These helpers read Clerk `publicMetadata`, which the browser can observe and
+ * a determined user can attempt to influence. They exist to decide whether to
+ * *render* an admin link, never to decide whether an action is allowed. The
+ * tests below therefore focus on the shapes an untrusted metadata bag can take.
+ */
+describe("client-side role helpers", () => {
+  it("recognises an exact ADMIN role", () => {
+    expect(isAdminClient({ role: "ADMIN" })).toBe(true);
+    expect(isFacultyClient({ role: "ADMIN" })).toBe(true);
+  });
+
+  it("treats FACULTY as faculty but not as admin", () => {
+    expect(isFacultyClient({ role: "FACULTY" })).toBe(true);
+    expect(isAdminClient({ role: "FACULTY" })).toBe(false);
+  });
+
+  it("grants nothing to STUDENT", () => {
+    expect(isAdminClient({ role: "STUDENT" })).toBe(false);
+    expect(isFacultyClient({ role: "STUDENT" })).toBe(false);
+  });
+
+  it("grants nothing when metadata is absent", () => {
+    for (const empty of [undefined, null, {}]) {
+      expect(isAdminClient(empty)).toBe(false);
+      expect(isFacultyClient(empty)).toBe(false);
+    }
+  });
+
+  it("grants nothing for values that merely resemble a role", () => {
+    // Case and whitespace variants must not pass. A metadata bag is attacker-
+    // adjacent data, and these helpers gate what a privileged UI reveals.
+    for (const lookalike of ["admin", "Admin", " ADMIN", "ADMIN ", "ADMINISTRATOR"]) {
+      expect(isAdminClient({ role: lookalike })).toBe(false);
+    }
+    for (const lookalike of ["faculty", "Faculty", " FACULTY"]) {
+      expect(isFacultyClient({ role: lookalike })).toBe(false);
+    }
+  });
+
+  it("grants nothing when role is a non-string", () => {
+    for (const wrongType of [1, true, {}, [], null, ["ADMIN"]]) {
+      expect(isAdminClient({ role: wrongType })).toBe(false);
+      expect(isFacultyClient({ role: wrongType })).toBe(false);
+    }
+  });
+
+  it("ignores unrelated metadata keys", () => {
+    expect(isAdminClient({ isAdmin: true, role: "STUDENT" })).toBe(false);
+    expect(isFacultyClient({ Role: "FACULTY" })).toBe(false);
+  });
+});

--- a/tests/unit/roles.test.ts
+++ b/tests/unit/roles.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { dbMock } from "./support/db";
+import { aRoleRow } from "./support/builders";
+
+vi.mock("@/lib/db", async () => ({
+  db: (await import("./support/db")).dbMock,
+}));
+
+const { getUserRole, isAdmin, isFaculty, isStudent } = await import("@/lib/roles");
+
+/**
+ * Authorization is the invariant with the worst failure mode in the product: a
+ * wrong answer here exposes another learner's data or hands out privilege. The
+ * tests below therefore assert the *deny* direction as carefully as the grant
+ * direction, and cover the boundaries between the three roles exhaustively.
+ *
+ * Related work: #42 replaces this module with a centralized RBAC and ownership
+ * module. These tests describe the behaviour that must survive that move.
+ */
+describe("getUserRole", () => {
+  beforeEach(() => {
+    delete process.env.TEACHER_ID;
+  });
+
+  it("returns the role persisted on the User row", async () => {
+    dbMock.user.findUnique.mockResolvedValue(aRoleRow("FACULTY"));
+
+    await expect(getUserRole("user_1")).resolves.toBe("FACULTY");
+  });
+
+  it("reads the role for the requested user and selects nothing else", async () => {
+    dbMock.user.findUnique.mockResolvedValue(aRoleRow("ADMIN"));
+
+    await getUserRole("user_42");
+
+    expect(dbMock.user.findUnique).toHaveBeenCalledWith({
+      where: { id: "user_42" },
+      select: { role: true },
+    });
+  });
+
+  it("defaults an unknown user to STUDENT rather than throwing", async () => {
+    dbMock.user.findUnique.mockResolvedValue(null);
+
+    await expect(getUserRole("ghost")).resolves.toBe("STUDENT");
+  });
+
+  it("defaults to STUDENT when the row exists but the role is null", async () => {
+    dbMock.user.findUnique.mockResolvedValue({ role: null });
+
+    await expect(getUserRole("user_1")).resolves.toBe("STUDENT");
+  });
+
+  describe("the TEACHER_ID environment backdoor", () => {
+    /**
+     * `lib/roles.ts` grants ADMIN to whoever matches `process.env.TEACHER_ID`,
+     * bypassing the database entirely. The matrix flags this as the reason row
+     * 1.7 is `partial`, and #42 removes it. Until then it is real production
+     * behaviour and is pinned here so its removal is a deliberate, visible
+     * change rather than an accident.
+     */
+    it("grants ADMIN on an exact match without consulting the database", async () => {
+      vi.stubEnv("TEACHER_ID", "teacher_1");
+
+      await expect(getUserRole("teacher_1")).resolves.toBe("ADMIN");
+      expect(dbMock.user.findUnique).not.toHaveBeenCalled();
+    });
+
+    it("does not grant ADMIN on a near match", async () => {
+      vi.stubEnv("TEACHER_ID", "teacher_1");
+      dbMock.user.findUnique.mockResolvedValue(aRoleRow("STUDENT"));
+
+      await expect(getUserRole("teacher_10")).resolves.toBe("STUDENT");
+      await expect(getUserRole("Teacher_1")).resolves.toBe("STUDENT");
+      await expect(getUserRole(" teacher_1")).resolves.toBe("STUDENT");
+    });
+
+    it("does not grant ADMIN to an empty user id when TEACHER_ID is unset", async () => {
+      // `undefined === ""` is false, so this must fall through to the database.
+      // If the comparison were ever loosened, an anonymous caller would become
+      // an administrator on any deployment that forgot to set TEACHER_ID.
+      dbMock.user.findUnique.mockResolvedValue(null);
+
+      await expect(getUserRole("")).resolves.toBe("STUDENT");
+      expect(dbMock.user.findUnique).toHaveBeenCalled();
+    });
+  });
+});
+
+describe("role predicates", () => {
+  const cases: Array<{
+    persisted: string | null;
+    admin: boolean;
+    faculty: boolean;
+    student: boolean;
+  }> = [
+    { persisted: "ADMIN", admin: true, faculty: true, student: false },
+    { persisted: "FACULTY", admin: false, faculty: true, student: false },
+    { persisted: "STUDENT", admin: false, faculty: false, student: true },
+    // Absent or unrecognised state must resolve to the least privilege.
+    { persisted: null, admin: false, faculty: false, student: true },
+  ];
+
+  for (const { persisted, admin, faculty, student } of cases) {
+    it(`resolves ${persisted ?? "an absent user"} to admin=${admin} faculty=${faculty} student=${student}`, async () => {
+      dbMock.user.findUnique.mockResolvedValue(aRoleRow(persisted));
+
+      await expect(isAdmin("user_1")).resolves.toBe(admin);
+      await expect(isFaculty("user_1")).resolves.toBe(faculty);
+      await expect(isStudent("user_1")).resolves.toBe(student);
+    });
+  }
+
+  it("treats ADMIN as a superset of FACULTY but never of STUDENT", async () => {
+    dbMock.user.findUnique.mockResolvedValue(aRoleRow("ADMIN"));
+
+    await expect(isFaculty("user_1")).resolves.toBe(true);
+    await expect(isStudent("user_1")).resolves.toBe(false);
+  });
+});
+
+/**
+ * Deliberate fault injection.
+ *
+ * Coverage percentages prove a line ran, not that it was checked. These cases
+ * corrupt the module's only dependency and assert the deny-by-default contract
+ * still holds — the property that actually protects learner data.
+ */
+describe("fault injection at the persistence boundary", () => {
+  it("denies privilege for role values the domain does not define", async () => {
+    for (const corrupt of ["admin", "Admin", "SUPERUSER", "", "  ADMIN  "]) {
+      dbMock.user.findUnique.mockResolvedValue({ role: corrupt });
+
+      await expect(isAdmin("user_1")).resolves.toBe(false);
+      await expect(isFaculty("user_1")).resolves.toBe(false);
+    }
+  });
+
+  it("denies privilege when the role arrives as a non-string", async () => {
+    for (const corrupt of [0, 1, true, {}, []]) {
+      dbMock.user.findUnique.mockResolvedValue({ role: corrupt });
+
+      await expect(isAdmin("user_1")).resolves.toBe(false);
+      await expect(isFaculty("user_1")).resolves.toBe(false);
+    }
+  });
+
+  it("does not grant ADMIN through type coercion at an untyped call site", async () => {
+    // TypeScript types `userId` as a string, but route handlers receive values
+    // that TypeScript never checked. If the identity comparison were ever
+    // loosened from `===` to `==`, an empty TEACHER_ID plus a coercible caller
+    // value (`[]`, `""`) would loosely compare equal and mint an administrator.
+    vi.stubEnv("TEACHER_ID", "");
+    dbMock.user.findUnique.mockResolvedValue(aRoleRow("STUDENT"));
+
+    for (const coercible of [[], "", 0, false, null, undefined]) {
+      await expect(
+        isAdmin(coercible as unknown as string)
+      ).resolves.toBe(false);
+    }
+  });
+
+  it("fails closed by propagating a database error instead of granting access", async () => {
+    dbMock.user.findUnique.mockRejectedValue(new Error("connection reset"));
+
+    // The caller must see the failure. Swallowing it and returning a default
+    // role would turn an outage into a silent authorization decision.
+    await expect(isAdmin("user_1")).rejects.toThrow("connection reset");
+  });
+});

--- a/tests/unit/streak-service.test.ts
+++ b/tests/unit/streak-service.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { aLearningStreak } from "./support/builders";
+import { dbMock } from "./support/db";
+import { dayStart, freezeTimeAt } from "./support/time";
+
+vi.mock("@/lib/db", async () => ({
+  db: (await import("./support/db")).dbMock,
+}));
+
+const { updateStreak } = await import("@/lib/streak-service");
+
+/**
+ * The streak rule is small but every branch of it is a date comparison, and
+ * date comparisons are where this codebase has historically been wrong. The
+ * clock is pinned for every case so a run at 23:59 UTC behaves like a run at
+ * noon.
+ *
+ * Related work: #83 (idempotency and concurrency) and #60 (timezone-safe
+ * progress dates) own the fixes characterised at the end of this file.
+ */
+const NOW = "2026-03-15T10:30:00.000Z";
+const TODAY = dayStart("2026-03-15");
+const YESTERDAY = dayStart("2026-03-14");
+
+function arriveWith(streak: Parameters<typeof aLearningStreak>[0]) {
+  dbMock.learningStreak.upsert.mockResolvedValue(aLearningStreak(streak));
+  dbMock.learningStreak.update.mockResolvedValue(aLearningStreak(streak));
+}
+
+describe("updateStreak", () => {
+  it("leaves the streak untouched when activity was already recorded today", async () => {
+    freezeTimeAt(NOW);
+    arriveWith({ currentStreak: 4, longestStreak: 9, lastActivityDate: TODAY });
+
+    await expect(updateStreak("user_1")).resolves.toBe(4);
+
+    // The second write is what makes the operation non-idempotent, so its
+    // absence is the actual assertion here.
+    expect(dbMock.learningStreak.update).not.toHaveBeenCalled();
+  });
+
+  it("increments on a consecutive day", async () => {
+    freezeTimeAt(NOW);
+    arriveWith({ currentStreak: 4, longestStreak: 9, lastActivityDate: YESTERDAY });
+
+    await expect(updateStreak("user_1")).resolves.toBe(5);
+
+    expect(dbMock.learningStreak.update).toHaveBeenCalledWith({
+      where: { userId: "user_1" },
+      data: { currentStreak: 5, longestStreak: 9, lastActivityDate: TODAY },
+    });
+  });
+
+  it("resets to 1 after a gap", async () => {
+    freezeTimeAt(NOW);
+    arriveWith({
+      currentStreak: 30,
+      longestStreak: 30,
+      lastActivityDate: dayStart("2026-03-13"),
+    });
+
+    await expect(updateStreak("user_1")).resolves.toBe(1);
+
+    expect(dbMock.learningStreak.update).toHaveBeenCalledWith({
+      where: { userId: "user_1" },
+      data: { currentStreak: 1, longestStreak: 30, lastActivityDate: TODAY },
+    });
+  });
+
+  it("resets to 1 when the record has never recorded activity", async () => {
+    freezeTimeAt(NOW);
+    arriveWith({ currentStreak: 0, longestStreak: 0, lastActivityDate: null });
+
+    await expect(updateStreak("user_1")).resolves.toBe(1);
+  });
+
+  it("creates a record for a first-time learner and counts it as day one", async () => {
+    freezeTimeAt(NOW);
+    arriveWith({ currentStreak: 1, longestStreak: 1, lastActivityDate: TODAY });
+
+    await expect(updateStreak("user_1")).resolves.toBe(1);
+
+    expect(dbMock.learningStreak.upsert).toHaveBeenCalledWith({
+      where: { userId: "user_1" },
+      create: {
+        userId: "user_1",
+        currentStreak: 1,
+        longestStreak: 1,
+        lastActivityDate: TODAY,
+      },
+      update: {},
+    });
+  });
+
+  describe("longest streak", () => {
+    it("advances when the current streak overtakes it", async () => {
+      freezeTimeAt(NOW);
+      arriveWith({ currentStreak: 9, longestStreak: 9, lastActivityDate: YESTERDAY });
+
+      await updateStreak("user_1");
+
+      expect(dbMock.learningStreak.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ currentStreak: 10, longestStreak: 10 }),
+        })
+      );
+    });
+
+    it("never decreases, including when the current streak resets", async () => {
+      freezeTimeAt(NOW);
+      arriveWith({
+        currentStreak: 30,
+        longestStreak: 30,
+        lastActivityDate: dayStart("2026-01-01"),
+      });
+
+      await updateStreak("user_1");
+
+      expect(dbMock.learningStreak.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ currentStreak: 1, longestStreak: 30 }),
+        })
+      );
+    });
+  });
+
+  describe("boundaries", () => {
+    it("counts a month boundary as consecutive", async () => {
+      freezeTimeAt("2026-03-01T00:00:01.000Z");
+      arriveWith({
+        currentStreak: 2,
+        longestStreak: 2,
+        lastActivityDate: dayStart("2026-02-28"),
+      });
+
+      await expect(updateStreak("user_1")).resolves.toBe(3);
+    });
+
+    it("counts a year boundary as consecutive", async () => {
+      freezeTimeAt("2026-01-01T12:00:00.000Z");
+      arriveWith({
+        currentStreak: 7,
+        longestStreak: 7,
+        lastActivityDate: dayStart("2025-12-31"),
+      });
+
+      await expect(updateStreak("user_1")).resolves.toBe(8);
+    });
+
+    it("ignores the time of day when comparing calendar dates", async () => {
+      // 23:59:59 today and 00:00:00 yesterday are one calendar day apart even
+      // though they are nearly 48 hours apart as instants.
+      freezeTimeAt("2026-03-15T23:59:59.999Z");
+      arriveWith({
+        currentStreak: 1,
+        longestStreak: 1,
+        lastActivityDate: new Date("2026-03-14T00:00:00.000Z"),
+      });
+
+      await expect(updateStreak("user_1")).resolves.toBe(2);
+    });
+
+    it("resets rather than credits a streak when the stored date is in the future", async () => {
+      // Clock skew or a bad backfill must not be able to inflate a streak.
+      freezeTimeAt(NOW);
+      arriveWith({
+        currentStreak: 5,
+        longestStreak: 5,
+        lastActivityDate: dayStart("2026-03-16"),
+      });
+
+      await expect(updateStreak("user_1")).resolves.toBe(1);
+    });
+  });
+
+  /**
+   * Characterisation tests. These pin defects that exist today so that the
+   * issues which fix them have a failing test to turn green. Delete them there
+   * rather than here.
+   */
+  describe("known defects", () => {
+    it("derives the new value from an earlier read, so concurrent calls lose an update (#83)", async () => {
+      freezeTimeAt(NOW);
+      arriveWith({ currentStreak: 4, longestStreak: 4, lastActivityDate: YESTERDAY });
+
+      const [first, second] = await Promise.all([
+        updateStreak("user_1"),
+        updateStreak("user_1"),
+      ]);
+
+      // Both callers read `currentStreak: 4` before either wrote, so both
+      // compute 5 and the second write silently overwrites the first. An
+      // atomic `{ increment: 1 }` would produce 5 and 6.
+      expect([first, second]).toEqual([5, 5]);
+      expect(dbMock.learningStreak.update).toHaveBeenCalledTimes(2);
+    });
+
+    it("compares dates in the server's local timezone, not the learner's (#60)", async () => {
+      // The service strips time with `new Date(y, m, d)`, which is server-local.
+      // Under TZ=UTC (pinned by the suite) an instant just after midnight UTC is
+      // "today"; for a learner in UTC-5 it is still the previous evening, so the
+      // same action can land on either side of a streak boundary depending on
+      // where the server runs.
+      freezeTimeAt("2026-03-15T00:30:00.000Z");
+      arriveWith({ currentStreak: 3, longestStreak: 3, lastActivityDate: YESTERDAY });
+
+      await expect(updateStreak("user_1")).resolves.toBe(4);
+      expect(process.env.TZ).toBe("UTC");
+    });
+  });
+});

--- a/tests/unit/support/builders.ts
+++ b/tests/unit/support/builders.ts
@@ -1,0 +1,152 @@
+import type {
+  Badge,
+  Certificate,
+  Enrollment,
+  LearningStreak,
+  Quiz,
+  QuizAttempt,
+  User,
+} from "@prisma/client";
+
+/**
+ * Domain builders.
+ *
+ * Every builder returns a valid, boring entity and takes an override patch, so
+ * a test states only the field it is actually about. `aUser({ role: "ADMIN" })`
+ * reads as an assertion about roles; a 12-field object literal does not.
+ *
+ * Identifiers are stable strings rather than random UUIDs — a failure message
+ * naming `course_1` is traceable, one naming a fresh UUID is not.
+ */
+
+const EPOCH = new Date("2026-01-01T00:00:00.000Z");
+
+function timestamps() {
+  return { createdAt: EPOCH, updatedAt: EPOCH };
+}
+
+export type Role = "STUDENT" | "FACULTY" | "ADMIN";
+
+export function aUser(overrides: Partial<User> = {}): User {
+  return {
+    id: "user_1",
+    email: "learner@example.test",
+    firstName: "Ama",
+    lastName: "Mensah",
+    imageUrl: null,
+    role: "STUDENT",
+    bio: null,
+    title: null,
+    specialization: null,
+    ...timestamps(),
+    ...overrides,
+  } as User;
+}
+
+/** The narrow projection `lib/roles.ts` actually selects. */
+export function aRoleRow(role: Role | string | null): { role: string } | null {
+  return role === null ? null : { role };
+}
+
+export function anEnrollment(overrides: Partial<Enrollment> = {}): Enrollment {
+  return {
+    id: "enrollment_1",
+    userId: "user_1",
+    courseId: "course_1",
+    status: "ACTIVE",
+    enrolledAt: EPOCH,
+    ...timestamps(),
+    ...overrides,
+  } as Enrollment;
+}
+
+export function aLearningStreak(
+  overrides: Partial<LearningStreak> = {}
+): LearningStreak {
+  return {
+    id: "streak_1",
+    userId: "user_1",
+    currentStreak: 1,
+    longestStreak: 1,
+    lastActivityDate: null,
+    updatedAt: EPOCH,
+    ...overrides,
+  } as LearningStreak;
+}
+
+export function aBadge(overrides: Partial<Badge> = {}): Badge {
+  return {
+    id: "badge_1",
+    name: "First Steps",
+    description: "Complete your first Topic.",
+    imageUrl: null,
+    type: "COMPLETION",
+    criteria: { type: "topics_completed", count: 1 },
+    ...timestamps(),
+    ...overrides,
+  } as Badge;
+}
+
+/** A badge whose criteria are stated inline, which is what most tests want. */
+export function aBadgeWithCriteria(
+  criteria: Record<string, unknown>,
+  overrides: Partial<Badge> = {}
+): Badge {
+  return aBadge({ criteria, ...overrides } as Partial<Badge>);
+}
+
+export function aQuiz(overrides: Partial<Quiz> = {}): Quiz {
+  return {
+    id: "quiz_1",
+    title: "Module 1 Check",
+    type: "MODULE_QUIZ",
+    timeLimitMinutes: null,
+    passingScore: 70,
+    isPublished: true,
+    courseId: "course_1",
+    moduleId: null,
+    ...timestamps(),
+    ...overrides,
+  } as Quiz;
+}
+
+export function aQuizAttempt(overrides: Partial<QuizAttempt> = {}): QuizAttempt {
+  return {
+    id: "attempt_1",
+    score: 80,
+    totalPoints: 100,
+    startedAt: EPOCH,
+    completedAt: EPOCH,
+    userId: "user_1",
+    quizId: "quiz_1",
+    ...timestamps(),
+    ...overrides,
+  } as QuizAttempt;
+}
+
+export function aCertificate(
+  overrides: Partial<Certificate> = {}
+): Certificate {
+  return {
+    id: "certificate_1",
+    certificateNumber: "GHELP-2026-00001",
+    issuedAt: EPOCH,
+    userId: "user_1",
+    courseId: "course_1",
+    pdfUrl: null,
+    ...overrides,
+  } as Certificate;
+}
+
+/** A published Module with published Topics, shaped as badge-service selects it. */
+export function aModuleWithTopics(
+  topicIds: string[],
+  overrides: Record<string, unknown> = {}
+) {
+  return {
+    id: "module_1",
+    isPublished: true,
+    topics: topicIds.map((id) => ({ id })),
+    ...overrides,
+  };
+}

--- a/tests/unit/support/db.ts
+++ b/tests/unit/support/db.ts
@@ -1,0 +1,95 @@
+import { vi } from "vitest";
+
+/**
+ * A Prisma test double.
+ *
+ * Domain logic under test must never reach a real database, so `@/lib/db` is
+ * replaced by this object. Delegates are created lazily by a Proxy, which means
+ * a test never has to enumerate the models a service happens to touch, and
+ * adding a model to a service does not require editing this file.
+ *
+ * Defaults are deliberately the *empty, deny-leaning* answers a fresh database
+ * would give: `null`, `[]`, `0`. A service that forgets to check its inputs
+ * therefore fails closed in tests rather than silently reading `undefined`.
+ * Writes have no default at all — a test that expects a write must say so.
+ */
+type Delegate = Record<string, ReturnType<typeof vi.fn>>;
+
+const READ_DEFAULTS: Record<string, unknown> = {
+  findUnique: null,
+  findFirst: null,
+  findMany: [],
+  count: 0,
+  aggregate: null,
+  groupBy: [],
+};
+
+const WRITE_METHODS = [
+  "create",
+  "createMany",
+  "update",
+  "updateMany",
+  "upsert",
+  "delete",
+  "deleteMany",
+] as const;
+
+function createDelegate(model: string): Delegate {
+  const delegate: Delegate = {};
+
+  for (const [method, value] of Object.entries(READ_DEFAULTS)) {
+    delegate[method] = vi.fn().mockResolvedValue(value);
+  }
+
+  for (const method of WRITE_METHODS) {
+    delegate[method] = vi.fn().mockRejectedValue(
+      new Error(
+        `db.${model}.${method}() was called but no result was configured. ` +
+          `Configure it explicitly in the test, e.g. ` +
+          `dbMock.${model}.${method}.mockResolvedValue(...).`
+      )
+    );
+  }
+
+  return delegate;
+}
+
+function createDbMock() {
+  const models = new Map<string, Delegate>();
+
+  return new Proxy({} as Record<string, Delegate>, {
+    get(_target, prop: string) {
+      if (prop === "$transaction") {
+        // Callback form runs inline against the same mock; array form resolves
+        // each promise. Real transactional guarantees are #107's job.
+        return vi.fn(async (arg: unknown) =>
+          typeof arg === "function"
+            ? await (arg as (tx: unknown) => unknown)(proxy)
+            : await Promise.all(arg as Promise<unknown>[])
+        );
+      }
+      if (!models.has(prop)) {
+        models.set(prop, createDelegate(prop));
+      }
+      return models.get(prop)!;
+    },
+  });
+}
+
+let proxy = createDbMock();
+
+/**
+ * The shared double. Test files wire it in with:
+ *
+ *   vi.mock("@/lib/db", async () => ({
+ *     db: (await import("./support/db")).dbMock,
+ *   }));
+ */
+export const dbMock = new Proxy({} as Record<string, Delegate>, {
+  get: (_t, prop: string) => proxy[prop],
+});
+
+/** Re-arms every delegate with its default. Called globally before each test. */
+export function resetDbMock(): void {
+  proxy = createDbMock();
+}

--- a/tests/unit/support/setup.ts
+++ b/tests/unit/support/setup.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, vi } from "vitest";
+
+import { resetDbMock } from "./db";
+
+/**
+ * Global determinism guarantees for the unit suite.
+ *
+ * A unit test that passes on one machine and fails on another is worse than no
+ * test, because it trains reviewers to re-run CI instead of reading failures.
+ * The three non-deterministic inputs available to this codebase are the clock,
+ * the timezone, and `Math.random`, so all three are pinned here.
+ */
+
+// The clock: the wall time a test observes must not depend on when CI runs.
+// Individual tests move the clock with `freezeTimeAt()` from ./time.
+process.env.TZ = "UTC";
+
+// `lib/roles.ts` grants ADMIN to `process.env.TEACHER_ID`. If a developer has
+// that set in a local shell, authorization tests would pass for the wrong
+// reason. Clear it; the tests that care set it explicitly.
+delete process.env.TEACHER_ID;
+
+const REAL_RANDOM = Math.random;
+
+/**
+ * A small deterministic PRNG (mulberry32). Seeded identically for every test so
+ * that any code reaching for `Math.random` gets a reproducible sequence rather
+ * than an irreproducible failure.
+ */
+function seededRandom(seed: number): () => number {
+  let state = seed;
+  return () => {
+    state |= 0;
+    state = (state + 0x6d2b79f5) | 0;
+    let t = Math.imul(state ^ (state >>> 15), 1 | state);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+beforeEach(() => {
+  // Re-arm the Prisma double *after* Vitest's own mockReset has run, so each
+  // test starts from the documented empty-database defaults.
+  resetDbMock();
+
+  Math.random = seededRandom(0x9e3779b9);
+
+  // Unit tests must not perform I/O. Failing loudly here is far easier to debug
+  // than a hung socket or, worse, a test that quietly hits a real service.
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: unknown) => {
+      throw new Error(
+        `Network access is not allowed in the unit suite (attempted fetch to ${String(input)}). ` +
+          `Mock the client, or move this case to the integration suite (#107).`
+      );
+    })
+  );
+});
+
+afterEach(() => {
+  Math.random = REAL_RANDOM;
+  vi.useRealTimers();
+});

--- a/tests/unit/support/time.ts
+++ b/tests/unit/support/time.ts
@@ -1,0 +1,23 @@
+import { vi } from "vitest";
+
+/**
+ * Pins the system clock to an exact instant for the duration of a test.
+ *
+ * Timers are faked but not advanced, so `new Date()` inside the code under test
+ * is stable while `await` still resolves normally. `afterEach` in ./setup
+ * restores real timers.
+ */
+export function freezeTimeAt(iso: string): Date {
+  const instant = new Date(iso);
+  if (Number.isNaN(instant.getTime())) {
+    throw new Error(`freezeTimeAt received an invalid instant: ${iso}`);
+  }
+  vi.useFakeTimers({ shouldAdvanceTime: true, now: instant });
+  return instant;
+}
+
+/** Midnight UTC on the given calendar date, matching how the app strips time. */
+export function dayStart(iso: string): Date {
+  const [year, month, day] = iso.split("-").map(Number);
+  return new Date(year, month - 1, day);
+}

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,0 +1,62 @@
+import { fileURLToPath } from "node:url";
+
+import { defineConfig } from "vitest/config";
+
+/**
+ * Unit-test harness for core authorization and domain invariants (#106).
+ *
+ * Scope: pure domain logic only. These tests must never boot Next.js, open a
+ * network socket, or reach a real database. Route-level, RLS, transaction, and
+ * webhook coverage belongs to the isolated PostgreSQL harness (#107); browser
+ * journeys belong to Playwright (#108).
+ *
+ * `coverage.include` is an allow-list, not a whole-repo sweep. A module joins
+ * the list in the same PR that brings it under test, so the thresholds below
+ * always describe real, enforced coverage rather than an aspiration diluted by
+ * hundreds of untested files. Issues #48, #49, #63, #73, #83, and #84 each add
+ * their own entries as they land.
+ */
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./", import.meta.url)),
+    },
+  },
+  test: {
+    environment: "node",
+    include: ["tests/unit/**/*.test.ts"],
+    setupFiles: ["tests/unit/support/setup.ts"],
+
+    // Determinism: no test may depend on another test's mock state.
+    clearMocks: true,
+    mockReset: true,
+    restoreMocks: true,
+    unstubEnvs: true,
+    unstubGlobals: true,
+
+    coverage: {
+      provider: "v8",
+      reporter: ["text-summary", "lcov", "html"],
+      reportsDirectory: "coverage/unit",
+      include: [
+        "lib/roles.ts",
+        "lib/roles-client.ts",
+        "lib/streak-service.ts",
+        "lib/badge-service.ts",
+        "lib/certificate-service.ts",
+      ],
+      thresholds: {
+        // Per-file, so a well-covered module cannot mask a bare one.
+        perFile: true,
+        lines: 90,
+        functions: 90,
+        branches: 85,
+        statements: 90,
+        // Authorization is the highest-risk surface in the codebase: every
+        // branch of it must be exercised, including the deny-by-default paths.
+        "lib/roles.ts": { lines: 100, functions: 100, branches: 100, statements: 100 },
+        "lib/roles-client.ts": { lines: 100, functions: 100, branches: 100, statements: 100 },
+      },
+    },
+  },
+});


### PR DESCRIPTION
Closes part of #106. The harness and its first coverage land here; #106 stays open until #48, #49, #63, #73, #83, and #84 add the coverage specified in its brief.

## What this does

Selects **Vitest** as the TypeScript unit-test runner and brings the five highest-risk domain modules under test.

- `vitest.config.mts` — `@/*` aliasing matching `tsconfig.json`, v8 coverage, **per-file** thresholds.
- `tests/unit/support/` — a Prisma test double, domain builders, and pinned clock, timezone, and randomness.
- 92 cases across `lib/roles.ts`, `lib/roles-client.ts`, `lib/streak-service.ts`, `lib/badge-service.ts`, `lib/certificate-service.ts`.
- A required **Unit Tests** CI job, with the coverage report uploaded as an artifact.
- `docs/agents/testing.md`, linked from `AGENTS.md` and `CLAUDE.md`.

### Why Vitest over `node --test`

`checks/` and `evals/` stay on `node --test`; porting them would add risk without adding coverage. The domain suite needs TypeScript, `@/*` resolution, module mocking for Prisma and Clerk, and coverage thresholds. `node --test` can do the first two via `tsx`, but ESM module mocking is still experimental and coverage *thresholds* need Node 22 — CI pins Node 20. This is recorded in the evals job comment.

### Coverage is an allow-list, not a sweep

`coverage.include` names individual files and thresholds are checked per file. A module joins the list in the same PR that brings it under test. A global average across hundreds of untested files says nothing, and one well-covered module must never be able to mask a bare one. `lib/roles.ts` and `lib/roles-client.ts` are held at 100%.

## Security fix included

`getUserRole` compared `userId === process.env.TEACHER_ID` to grant ADMIN. `TEACHER_ID` is `z.string().optional()` (`lib/env.ts:39`), so a **blank** value is valid configuration — and a blank `userId` is what an unauthenticated caller produces. On a deployment defining the variable but leaving it empty, `"" === ""` granted ADMIN.

**Not currently exploitable**: all 20+ callers guard with `if (!userId)` first, which rejects `""`. This is defence-in-depth — the grant should not depend on every present and future caller remembering that guard. Fixed by requiring both operands to be non-empty; regression test in `tests/unit/roles.test.ts`. Flagged for #42, which replaces this module.

## Evidence the tests catch defects

Coverage proves a line ran, not that anything was checked. Six mutations were applied to `lib/roles.ts`:

| Mutation | Result |
| --- | --- |
| `isAdmin`: `=== "ADMIN"` → `!== "STUDENT"` | killed |
| role fallback: `?? "STUDENT"` → `?? "ADMIN"` | killed |
| `isFaculty`: drop the ADMIN superset | killed |
| `isStudent`: invert | killed |
| drop the non-empty TEACHER_ID guard | killed |
| `===` → `==` | **equivalent** — the guard makes both operands non-empty strings, so the operators cannot differ |

Five killed, one provably equivalent.

## Known defects recorded, not hidden

Two characterisation tests in `tests/unit/streak-service.test.ts` pin real defects so the owning issues have a failing test to turn green:

- `updateStreak` derives its next value from an earlier read, so concurrent calls lose an update — **#83**.
- It compares calendar dates in the server's timezone, not the learner's — **#60**.

Both sit under a `known defects` block and should be deleted by the PR that fixes them.

## Also fixed

`checks/docs-consistency.test.mjs` matched npm scripts with `[a-z:]+`, excluding digits, so it truncated `test:e2e` to `test:e` and reported the truncation as a missing script. No document had referenced a script with a digit until this one. Verified the check still catches genuinely missing scripts.

## Commands run

```
npm run validate     # lint, typecheck, test:unit, test:evals, test:checks — all pass
npm run test:unit:coverage
```

```
Test Files  5 passed (5)
     Tests  92 passed (92)

Statements   : 98.1%  (155/158)
Branches     : 93.89% (123/131)
Functions    : 100%   (24/24)
Lines        : 100%   (135/135)
```

## Rollout

Test-only apart from the three-line authorization guard. No migration, no schema change, no user-visible behaviour change. Rollback is a revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RH1AUJJFKCXc2SuRcML9vg
