### PR TITLE
feat: add the centralized RBAC permission module and retire TEACHER_ID

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,8 +57,15 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
 
 # -----------------------------------------------------------------------------
-# Optional
+# Roles
 # -----------------------------------------------------------------------------
-# Server-only Clerk user id treated as ADMIN (backward-compat bootstrap only;
-# prefer the User.role column). NOTE: code reads TEACHER_ID (not NEXT_PUBLIC_TEACHER_ID).
-TEACHER_ID=user_...
+# There is no environment variable for administration. TEACHER_ID was removed in
+# issue #42: privilege comes from the User.role column and nothing else, so that
+# it can participate in a transaction and in a row-level security policy
+# (docs/adr/0001-identity-authentication-and-rbac.md).
+#
+# To grant the first administrator, have them sign in once so the Clerk webhook
+# creates their User row, then run:
+#
+#   npm run role:grant -- --user <clerkUserId> --role ADMIN
+#   npm run role:check

--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,9 @@ CHANGELOG.md
 !/docs/ai/**
 !/docs/release/
 !/docs/release/**
+# The permission matrix: the authorization rules every contributor and agent
+# must implement against, asserted by tests/unit/auth/policy.test.ts.
+!/docs/permission-matrix.md
 # Phase specifications: the historical record the release matrix audits
 # against. Committed so that audit is reproducible by anyone.
 !/docs/phase-1.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ This repository uses a single-context domain documentation layout. See `docs/age
 - `DESIGN.md`: approved tokens, navigation, responsive floors, accessibility baseline, exception process.
 - `CONTEXT.md`: canonical domain terms, legacy terminology, invariants.
 - `docs/adr/`: approved architectural seams. Start at `docs/adr/README.md`.
+- `docs/permission-matrix.md`: who may perform which action on which resource. Binding on every route handler, server action, and page.
 - `docs/policies/`: data protection, retention, AI safety, educational scope, support, incident response, moderation, and the obligation-to-control map. Start at `docs/policies/README.md`.
 - `docs/release/`: the Phase 1 to 5 implementation matrix and the v1 release checklist. Start at `docs/release/implementation-matrix.md`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ This repository uses a single-context domain documentation layout. See `docs/age
 - `DESIGN.md`: approved tokens, navigation, responsive floors, accessibility baseline, exception process.
 - `CONTEXT.md`: canonical domain terms, legacy terminology, invariants.
 - `docs/adr/`: approved architectural seams. Start at `docs/adr/README.md`.
+- `docs/permission-matrix.md`: who may perform which action on which resource. Binding on every route handler, server action, and page.
 - `docs/policies/`: data protection, retention, AI safety, educational scope, support, incident response, moderation, and the obligation-to-control map. Start at `docs/policies/README.md`.
 - `docs/release/`: the Phase 1 to 5 implementation matrix and the v1 release checklist. Start at `docs/release/implementation-matrix.md`.
 

--- a/docs/permission-matrix.md
+++ b/docs/permission-matrix.md
@@ -1,0 +1,159 @@
+# Permission matrix
+
+The authorization rules for Akomapa Academy, as enforced by `lib/auth/policy.ts`.
+
+This document and that module must agree. The matrix is executable: every row
+below is asserted in `tests/unit/auth/policy.test.ts`, and the action vocabulary
+in `lib/auth/actions.ts` is mapped to rules by a total `Record<Action, Rule>`, so
+adding an action without deciding who may perform it does not compile.
+
+Implements [ADR 0001](adr/0001-identity-authentication-and-rbac.md). Owned by
+[#42](https://github.com/akomapahealth/akomapa-lms/issues/42).
+
+## Principles
+
+1. **One derivation point.** `requirePrincipal()` in `lib/auth/principal.ts` is
+   the only place a principal is produced. Nothing else calls Clerk's `auth()`
+   and reasons about the result.
+2. **Deny by default.** An absent principal, an unrecognised role, an unknown
+   action, or a resource whose relationship cannot be established denies the
+   request. A missing check is a denial, never an allow.
+3. **`ADMIN` implies `FACULTY`.** `FACULTY` does not imply `ADMIN`. `STUDENT`
+   implies neither.
+4. **Ownership is asserted in the query.** The `authorize*` guards in
+   `lib/auth/guards.ts` put the ownership condition inside the statement that
+   loads the resource, so an authorized-but-unrelated row is never read.
+5. **Nothing is taken from the browser.** Role, ownership, price, score,
+   completion, and entitlement are never read from a request body, query string,
+   header, or client prop.
+
+## Rules
+
+Each action maps to exactly one rule.
+
+| Rule | Meaning |
+| --- | --- |
+| `adminOnly` | `ADMIN` only. Ownership is not consulted. |
+| `facultyGlobal` | `FACULTY` or `ADMIN`. No resource ownership required. |
+| `facultyOwned` | `FACULTY` or `ADMIN` **and** the principal owns the resource. |
+| `authorOrModerator` | The content's author, or any principal holding `community:moderate`. |
+| `activeEnrollment` | An Enrollment whose status is `ACTIVE` or `COMPLETED`. |
+| `reserved` | Denied unconditionally until the owning issue implements the surface. |
+
+### Ownership
+
+Ownership is already modelled in `prisma/schema.prisma` and needs no migration.
+
+- **Course** — `Course.userId`, the creator.
+- **Module** — the owning Course's creator, **or** `Module.facultyId`, the
+  assigned faculty member. Assigned teaching is deliberately modelled separately
+  from global administration.
+- **Community content** — `ForumPost.userId` / `ForumComment.userId`.
+
+## The matrix
+
+### Course authoring
+
+| Action | Rule | STUDENT | FACULTY (owner) | FACULTY (other) | ADMIN (owner) | ADMIN (other) |
+| --- | --- | --- | --- | --- | --- | --- |
+| `course:create` | `facultyGlobal` | deny | allow | allow | allow | allow |
+| `course:read` | `facultyOwned` | deny | allow | deny | allow | deny |
+| `course:update` | `facultyOwned` | deny | allow | deny | allow | deny |
+| `course:delete` | `facultyOwned` | deny | allow | deny | allow | deny |
+| `course:publish` | `facultyOwned` | deny | allow | deny | allow | deny |
+| `module:*`, `topic:*`, `attachment:*` | `facultyOwned` | deny | allow | deny | allow | deny |
+| `upload:courseAsset` | `facultyGlobal` | deny | allow | allow | allow | allow |
+
+**ADMIN does not override Course ownership.** This preserves what
+`DELETE /api/courses/[courseId]` enforces today. Whether an ADMIN should be able
+to edit any Course is a product decision owned by
+[#86](https://github.com/akomapahealth/akomapa-lms/issues/86); changing it means
+changing this table and the tests that assert it, deliberately.
+
+### Assessment authoring
+
+| Action | Rule | STUDENT | FACULTY (owner) | FACULTY (other) | ADMIN (other) |
+| --- | --- | --- | --- | --- | --- |
+| `quiz:create` | `facultyOwned` | deny | allow | deny | deny |
+| `quiz:read`, `quiz:update`, `quiz:delete`, `quiz:publish` | `facultyOwned` | deny | allow | deny | deny |
+| `question:create`, `question:update`, `question:delete`, `question:reorder` | `facultyOwned` | deny | allow | deny | deny |
+| `caseStudy:create`, `caseStudy:update`, `caseStudy:delete` | `facultyOwned` | deny | allow | deny | deny |
+
+### Community
+
+| Action | Rule | STUDENT (author) | STUDENT (other) | FACULTY (other) | ADMIN |
+| --- | --- | --- | --- | --- | --- |
+| `post:update`, `post:delete` | `authorOrModerator` | allow | deny | deny | allow |
+| `comment:update`, `comment:delete` | `authorOrModerator` | allow | deny | deny | allow |
+| `community:moderate` | `adminOnly` | deny | deny | deny | allow |
+
+`community:moderate` covers pinning, locking, category management, and acting on
+content the principal did not write.
+
+### Administration
+
+| Action | Rule | STUDENT | FACULTY | ADMIN |
+| --- | --- | --- | --- | --- |
+| `analytics:read` | `adminOnly` | deny | deny | allow |
+| `learner:administer` | `adminOnly` | deny | deny | allow |
+| `role:manage` | `adminOnly` | deny | deny | allow |
+
+`role:manage` has no user interface yet;
+[#88](https://github.com/akomapahealth/akomapa-lms/issues/88) builds it. Until
+then roles are granted with `npm run role:grant` (see below).
+
+### Learner access
+
+| Action | Rule | `ACTIVE` | `COMPLETED` | `SUSPENDED` | no Enrollment |
+| --- | --- | --- | --- | --- | --- |
+| `course:learn` | `activeEnrollment` | allow | allow | deny | deny |
+
+Privilege does not buy back a suspension: an ADMIN with a `SUSPENDED` Enrollment
+is denied. The full entitlement rule — purchase, Enrollment as the canonical
+record, free-preview Topics — is
+[ADR 0002](adr/0002-enrollment-as-canonical-entitlement.md) and
+[#48](https://github.com/akomapahealth/akomapa-lms/issues/48). What this rule
+owns is the narrower suspension invariant.
+
+### Reserved
+
+| Action | Rule | Everyone | Owning issue |
+| --- | --- | --- | --- |
+| `billing:administer` | `reserved` | deny | [#72](https://github.com/akomapahealth/akomapa-lms/issues/72), [#73](https://github.com/akomapahealth/akomapa-lms/issues/73) |
+| `ai:administer` | `reserved` | deny | [#79](https://github.com/akomapahealth/akomapa-lms/issues/79) |
+
+These names exist so that a future caller cannot assume an unnamed action is
+permitted. They deny for every role until their owning issue implements them.
+
+## Denial responses
+
+| Reason | Status | When |
+| --- | --- | --- |
+| `unauthenticated` | 401 | No principal. |
+| `forbidden` | 403 | Authenticated, but the role cannot perform this action on any resource. |
+| `not_found` | 404 | The resource is absent, **or** present and not the principal's. |
+
+The last two cases are deliberately indistinguishable. Answering 403 for "exists
+but is not yours" and 404 for "does not exist" turns an endpoint into an oracle
+for enumerating other people's Courses.
+
+## Granting roles
+
+Privilege comes from `User.role` and nothing else. The `TEACHER_ID` environment
+variable was removed in #42 (ADR 0001 §6).
+
+There is no in-app way to grant the first ADMIN, so a deployment with no ADMIN
+row cannot be administered and cannot repair itself. Before deploying:
+
+```
+npm run role:grant -- --user <clerkUserId> --role ADMIN
+npm run role:list     # confirm
+npm run role:check    # exits non-zero if no ADMIN exists
+```
+
+The user must sign in once first, so the Clerk webhook creates their `User` row.
+
+`assertAdminExists()` in `lib/auth/bootstrap.ts` is the same check as a function,
+ready for [#103](https://github.com/akomapahealth/akomapa-lms/issues/103) to
+mount on a readiness endpoint. Until that endpoint exists, `npm run role:check`
+is a **manual** deploy step — CI cannot run it, because CI has no database.

--- a/lib/auth/actions.ts
+++ b/lib/auth/actions.ts
@@ -1,0 +1,83 @@
+/**
+ * The action vocabulary.
+ *
+ * Every authorization decision in the application names one of these. The union
+ * is exhaustive on purpose: a typo becomes a build error rather than a check
+ * that silently never matches, and `policy.ts` must map every member to a rule,
+ * so adding an action without deciding who may perform it does not compile.
+ *
+ * Actions are named `subject:verb`. The subject is the domain noun from
+ * CONTEXT.md, never a route path — routes move, the domain does not.
+ */
+export const ACTIONS = [
+  // Course authoring. Ownership is required; see docs/permission-matrix.md.
+  "course:create",
+  "course:read",
+  "course:update",
+  "course:delete",
+  "course:publish",
+
+  // Module, Topic, and Attachment authoring. These hang off a Course, so
+  // ownership resolves through the owning Course or an assigned faculty member.
+  "module:create",
+  "module:update",
+  "module:delete",
+  "module:reorder",
+  "topic:create",
+  "topic:update",
+  "topic:delete",
+  "topic:reorder",
+  "attachment:create",
+  "attachment:delete",
+
+  // Assessment authoring.
+  "quiz:create",
+  "quiz:read",
+  "quiz:update",
+  "quiz:delete",
+  "quiz:publish",
+  "question:create",
+  "question:update",
+  "question:delete",
+  "question:reorder",
+
+  // Case Study authoring.
+  "caseStudy:create",
+  "caseStudy:update",
+  "caseStudy:delete",
+
+  // Community. `community:moderate` is the ADMIN capability covering pinning,
+  // locking, category management, and acting on content the principal did not
+  // write. Authors edit and delete their own content without it.
+  "community:moderate",
+  "post:update",
+  "post:delete",
+  "comment:update",
+  "comment:delete",
+
+  // Administration.
+  "analytics:read",
+  "learner:administer",
+  "role:manage",
+
+  // Learner access to purchased Course content.
+  "course:learn",
+
+  // Authoring uploads (course images, attachments, Topic video).
+  "upload:courseAsset",
+
+  // Reserved. These surfaces do not exist yet, so the policy denies them
+  // unconditionally rather than leaving the name free for a future caller to
+  // assume is permitted. #72/#73 and #79 own them.
+  "billing:administer",
+  "ai:administer",
+] as const;
+
+export type Action = (typeof ACTIONS)[number];
+
+const ACTION_SET: ReadonlySet<string> = new Set(ACTIONS);
+
+/** Narrows an untrusted string to a known action. Unknown input is not an action. */
+export function isAction(value: unknown): value is Action {
+  return typeof value === "string" && ACTION_SET.has(value);
+}

--- a/lib/auth/bootstrap.ts
+++ b/lib/auth/bootstrap.ts
@@ -1,0 +1,30 @@
+import "server-only";
+
+import { db } from "@/lib/db";
+
+/**
+ * The invariant that makes retiring TEACHER_ID safe.
+ *
+ * Privilege now comes only from `User.role`. If a deployment reaches production
+ * with no ADMIN row, nobody can administer it and there is no in-app way to fix
+ * that -- role management is #88 and does not exist yet. So the count is
+ * checked explicitly rather than assumed.
+ *
+ * This is currently exercised by `npm run role:check` as a deploy pre-flight.
+ * There is no readiness endpoint to mount it on yet; #103 adds one, and should
+ * call `assertAdminExists` from it.
+ */
+export async function countAdmins(): Promise<number> {
+  return db.user.count({ where: { role: "ADMIN" } });
+}
+
+export async function assertAdminExists(): Promise<void> {
+  const admins = await countAdmins();
+  if (admins === 0) {
+    throw new Error(
+      "No user has role ADMIN. Administration is unreachable and cannot be " +
+        "granted from inside the application. Run: " +
+        "npm run role:grant -- --user <clerkUserId> --role ADMIN"
+    );
+  }
+}

--- a/lib/auth/errors.ts
+++ b/lib/auth/errors.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from "next/server";
+
+/**
+ * Why a request was denied.
+ *
+ * The distinction matters to the client. Returning 401 for a permission failure
+ * -- which is what every handler does today -- makes the web app redirect a
+ * signed-in user to the sign-in page, where signing in again changes nothing.
+ */
+export type DenialReason =
+  /** No principal at all. */
+  | "unauthenticated"
+  /** Authenticated, but the role cannot perform this action anywhere. */
+  | "forbidden"
+  /**
+   * The resource does not exist, or exists and is not the principal's.
+   *
+   * These two are deliberately indistinguishable. Answering 403 for "exists but
+   * is not yours" and 404 for "does not exist" turns the endpoint into an
+   * oracle for enumerating other people's Courses.
+   */
+  | "not_found";
+
+export class Denied extends Error {
+  readonly reason: DenialReason;
+  readonly action?: string;
+
+  constructor(reason: DenialReason, action?: string) {
+    // The message is for server logs. It names the action, never the resource
+    // id, the principal, or anything else that should not reach a log line.
+    super(action ? `denied: ${reason} (${action})` : `denied: ${reason}`);
+    this.name = "Denied";
+    this.reason = reason;
+    this.action = action;
+  }
+}
+
+const STATUS: Record<DenialReason, number> = {
+  unauthenticated: 401,
+  forbidden: 403,
+  not_found: 404,
+};
+
+const BODY: Record<DenialReason, string> = {
+  unauthenticated: "Unauthorized",
+  forbidden: "Forbidden",
+  not_found: "Not Found",
+};
+
+export function isDenied(error: unknown): error is Denied {
+  return error instanceof Denied;
+}
+
+/**
+ * Converts a denial into a response. Returns null for anything else, so a
+ * handler's catch block can re-raise genuine faults instead of reporting an
+ * internal error as a permission problem.
+ */
+export function toResponse(error: unknown): NextResponse | null {
+  if (!isDenied(error)) return null;
+  return new NextResponse(BODY[error.reason], { status: STATUS[error.reason] });
+}

--- a/lib/auth/guards.ts
+++ b/lib/auth/guards.ts
@@ -1,0 +1,126 @@
+import "server-only";
+
+import { db } from "@/lib/db";
+
+import type { Action } from "./actions";
+import { Denied } from "./errors";
+import { can, type Principal } from "./policy";
+
+/**
+ * The async authorization boundary.
+ *
+ * ADR 0001 section 4: authorization is not a guard that runs before an
+ * unfiltered query. Each function here puts the ownership condition *inside*
+ * the query that loads the resource, so there is no window in which an
+ * authorized-but-unrelated row has been read and is waiting to be returned by
+ * mistake. The guard and the fetch are one statement.
+ *
+ * Each returns the resource on success and throws `Denied` otherwise, which
+ * separates the two failure modes a caller must distinguish:
+ *
+ *   forbidden  -- the role cannot perform this action on any resource
+ *   not_found  -- the resource is absent, or present and not the principal's
+ */
+
+/**
+ * Would this principal be allowed to perform the action on a resource it owns?
+ *
+ * Answering this before touching the database means a STUDENT probing an
+ * authoring endpoint gets 403 without costing a query, and it keeps "wrong
+ * role" distinct from "wrong resource" in the response.
+ */
+function canIfOwned(principal: Principal, action: Action): boolean {
+  return can(principal, action, {
+    kind: "course",
+    ownerId: principal.userId,
+  });
+}
+
+/** Asserts a capability that needs no resource: ADMIN powers, and `course:create`. */
+export function requireCapability(principal: Principal, action: Action): void {
+  if (!can(principal, action, { kind: "global" })) {
+    throw new Denied("forbidden", action);
+  }
+}
+
+/** Loads a Course the principal owns, or denies. */
+export async function authorizeCourse(
+  principal: Principal,
+  action: Action,
+  courseId: string
+) {
+  if (!canIfOwned(principal, action)) throw new Denied("forbidden", action);
+
+  const course = await db.course.findFirst({
+    where: { id: courseId, userId: principal.userId },
+  });
+
+  if (!course) throw new Denied("not_found", action);
+  return course;
+}
+
+/**
+ * Loads a Module the principal may author, asserting the full Course -> Module
+ * relationship so a Module id from another Course cannot be smuggled in.
+ *
+ * Ownership is either the Course creator or the Module's assigned faculty
+ * member, which is the distinction between global administration and assigned
+ * teaching that #42 requires be modelled separately.
+ */
+export async function authorizeModuleInCourse(
+  principal: Principal,
+  action: Action,
+  courseId: string,
+  moduleId: string
+) {
+  if (!canIfOwned(principal, action)) throw new Denied("forbidden", action);
+
+  const courseModule = await db.module.findFirst({
+    where: {
+      id: moduleId,
+      courseId,
+      OR: [
+        { course: { userId: principal.userId } },
+        { facultyId: principal.userId },
+      ],
+    },
+  });
+
+  if (!courseModule) throw new Denied("not_found", action);
+  return courseModule;
+}
+
+/**
+ * Authorizes an action on learner-authored content.
+ *
+ * The author may act on their own content; a moderator may act on anyone's.
+ * Both paths are expressed once here rather than repeated at the three call
+ * sites in the community routes that currently inline the same comparison.
+ */
+export async function authorizePost(
+  principal: Principal,
+  action: Action,
+  postId: string
+) {
+  const post = await db.forumPost.findUnique({ where: { id: postId } });
+  if (!post) throw new Denied("not_found", action);
+
+  if (!can(principal, action, { kind: "authored", authorId: post.userId })) {
+    throw new Denied("forbidden", action);
+  }
+  return post;
+}
+
+export async function authorizeComment(
+  principal: Principal,
+  action: Action,
+  commentId: string
+) {
+  const comment = await db.forumComment.findUnique({ where: { id: commentId } });
+  if (!comment) throw new Denied("not_found", action);
+
+  if (!can(principal, action, { kind: "authored", authorId: comment.userId })) {
+    throw new Denied("forbidden", action);
+  }
+  return comment;
+}

--- a/lib/auth/index.ts
+++ b/lib/auth/index.ts
@@ -1,0 +1,32 @@
+/**
+ * Centralized authorization (ADR 0001, issue #42).
+ *
+ * Import from `@/lib/auth` rather than from the individual files, so the
+ * surface a handler depends on stays small and the module can be reorganised
+ * without touching call sites.
+ *
+ * The matrix these rules encode is documented in docs/permission-matrix.md.
+ */
+export { ACTIONS, isAction, type Action } from "./actions";
+export {
+  can,
+  normalizeRole,
+  type Principal,
+  type Resource,
+  type Role,
+} from "./policy";
+export {
+  Denied,
+  isDenied,
+  toResponse,
+  type DenialReason,
+} from "./errors";
+export { getPrincipal, requirePrincipal } from "./principal";
+export {
+  authorizeComment,
+  authorizeCourse,
+  authorizeModuleInCourse,
+  authorizePost,
+  requireCapability,
+} from "./guards";
+export { assertAdminExists, countAdmins } from "./bootstrap";

--- a/lib/auth/policy.ts
+++ b/lib/auth/policy.ts
@@ -1,0 +1,210 @@
+import { type Action, isAction } from "./actions";
+
+/**
+ * The permission matrix, as a pure function.
+ *
+ * Nothing here touches the database, the network, or the clock. That is the
+ * whole point: every role x action x ownership combination can be asserted in a
+ * unit test that runs in microseconds, so the matrix is cheap to cover
+ * exhaustively rather than sampled. The async work of *loading* a resource with
+ * its ownership asserted lives in `guards.ts`.
+ *
+ * Implements ADR 0001. Documented in docs/permission-matrix.md.
+ */
+
+export type Role = "STUDENT" | "FACULTY" | "ADMIN";
+
+export interface Principal {
+  userId: string;
+  role: Role;
+}
+
+/**
+ * What a decision is being made *about*.
+ *
+ * A rule and a resource must agree in kind. A mismatch is a denial, never a
+ * fallthrough: asking whether a principal may update a Course while passing a
+ * forum post is a programming error, and the safe answer to a programming error
+ * in an authorization path is "no".
+ */
+export type Resource =
+  /** No resource: the action is global, or the resource does not exist yet. */
+  | { kind: "global" }
+  /** A Course, identified by its creator. */
+  | { kind: "course"; ownerId: string }
+  /** A Module: owned by the Course creator, or by its assigned faculty member. */
+  | { kind: "module"; courseOwnerId: string; assignedFacultyId: string | null }
+  /** Learner-authored content: a forum post, a comment. */
+  | { kind: "authored"; authorId: string }
+  /** A learner's relationship to a Course. */
+  | { kind: "enrollment"; status: string };
+
+type Rule =
+  /** ADMIN only. Ownership is not consulted. */
+  | "adminOnly"
+  /** FACULTY or ADMIN. No resource ownership required. */
+  | "facultyGlobal"
+  /** FACULTY or ADMIN, and the principal must own the resource. */
+  | "facultyOwned"
+  /** The author, or anyone holding `community:moderate`. */
+  | "authorOrModerator"
+  /** A learner whose Enrollment is not suspended. */
+  | "activeEnrollment"
+  /** Reserved: denied unconditionally until the owning issue implements it. */
+  | "reserved";
+
+/**
+ * Every action maps to exactly one rule. `Record<Action, Rule>` makes this
+ * total: adding an action to the vocabulary without deciding its rule is a
+ * type error.
+ */
+const RULES: Record<Action, Rule> = {
+  "course:create": "facultyGlobal",
+  "course:read": "facultyOwned",
+  "course:update": "facultyOwned",
+  "course:delete": "facultyOwned",
+  "course:publish": "facultyOwned",
+
+  "module:create": "facultyOwned",
+  "module:update": "facultyOwned",
+  "module:delete": "facultyOwned",
+  "module:reorder": "facultyOwned",
+  "topic:create": "facultyOwned",
+  "topic:update": "facultyOwned",
+  "topic:delete": "facultyOwned",
+  "topic:reorder": "facultyOwned",
+  "attachment:create": "facultyOwned",
+  "attachment:delete": "facultyOwned",
+
+  "quiz:create": "facultyOwned",
+  "quiz:read": "facultyOwned",
+  "quiz:update": "facultyOwned",
+  "quiz:delete": "facultyOwned",
+  "quiz:publish": "facultyOwned",
+  "question:create": "facultyOwned",
+  "question:update": "facultyOwned",
+  "question:delete": "facultyOwned",
+  "question:reorder": "facultyOwned",
+
+  "caseStudy:create": "facultyOwned",
+  "caseStudy:update": "facultyOwned",
+  "caseStudy:delete": "facultyOwned",
+
+  "community:moderate": "adminOnly",
+  "post:update": "authorOrModerator",
+  "post:delete": "authorOrModerator",
+  "comment:update": "authorOrModerator",
+  "comment:delete": "authorOrModerator",
+
+  "analytics:read": "adminOnly",
+  "learner:administer": "adminOnly",
+  "role:manage": "adminOnly",
+
+  "course:learn": "activeEnrollment",
+
+  "upload:courseAsset": "facultyGlobal",
+
+  "billing:administer": "reserved",
+  "ai:administer": "reserved",
+};
+
+/**
+ * Narrows an untrusted role value to a known role.
+ *
+ * Anything else -- a lowercase variant, a padded string, a non-string that
+ * survived an untyped call site -- is not a role, and a principal without a
+ * role gets nothing above STUDENT. This is the guard that makes a corrupted or
+ * hand-edited `User.role` fail closed instead of open.
+ */
+export function normalizeRole(value: unknown): Role | null {
+  return value === "STUDENT" || value === "FACULTY" || value === "ADMIN"
+    ? value
+    : null;
+}
+
+function isAtLeastFaculty(role: Role): boolean {
+  // ADR 0001 section 3: ADMIN implies FACULTY; FACULTY does not imply ADMIN.
+  return role === "FACULTY" || role === "ADMIN";
+}
+
+/** Does this principal own the resource well enough to author it? */
+function ownsForAuthoring(principal: Principal, resource: Resource): boolean {
+  switch (resource.kind) {
+    case "course":
+      return principal.userId === resource.ownerId;
+    case "module":
+      // Either the Course creator, or the faculty member assigned to this
+      // Module. `assignedFacultyId` is nullable, and null must never match a
+      // principal whose id is also absent.
+      return (
+        principal.userId === resource.courseOwnerId ||
+        (resource.assignedFacultyId !== null &&
+          principal.userId === resource.assignedFacultyId)
+      );
+    default:
+      // An authoring action was asked about a resource that carries no
+      // authoring ownership. Deny rather than guess.
+      return false;
+  }
+}
+
+/**
+ * The authorization decision.
+ *
+ * Returns `false` for every unknown, absent, or contradictory input rather than
+ * throwing, so a caller can never accidentally treat a thrown error as a grant.
+ */
+export function can(
+  principal: Principal | null | undefined,
+  action: Action,
+  resource: Resource = { kind: "global" }
+): boolean {
+  if (!principal) return false;
+
+  // An empty user id is what an unauthenticated caller produces. It must never
+  // match an owner id, including an owner id that is itself empty.
+  if (typeof principal.userId !== "string" || principal.userId.length === 0) {
+    return false;
+  }
+
+  const role = normalizeRole(principal.role);
+  if (role === null) return false;
+
+  // `isAction` narrows to the vocabulary, and `RULES` is a total
+  // `Record<Action, Rule>`, so the lookup below cannot miss. That totality is
+  // enforced by the type system rather than by a runtime guard, which is why
+  // there is no undefined check here: adding an action without a rule fails to
+  // compile.
+  if (!isAction(action)) return false;
+  const rule = RULES[action];
+
+  switch (rule) {
+    case "adminOnly":
+      return role === "ADMIN";
+
+    case "facultyGlobal":
+      return isAtLeastFaculty(role);
+
+    case "facultyOwned":
+      return isAtLeastFaculty(role) && ownsForAuthoring(principal, resource);
+
+    case "authorOrModerator":
+      if (role === "ADMIN") return true;
+      return (
+        resource.kind === "authored" &&
+        resource.authorId.length > 0 &&
+        principal.userId === resource.authorId
+      );
+
+    case "activeEnrollment":
+      // Entitlement in full is ADR 0002 / #48. What this rule owns is the
+      // narrower invariant that a suspended learner loses access.
+      return (
+        resource.kind === "enrollment" &&
+        (resource.status === "ACTIVE" || resource.status === "COMPLETED")
+      );
+
+    case "reserved":
+      return false;
+  }
+}

--- a/lib/auth/principal.ts
+++ b/lib/auth/principal.ts
@@ -1,0 +1,43 @@
+import "server-only";
+
+import { auth } from "@clerk/nextjs/server";
+
+import { db } from "@/lib/db";
+
+import { Denied } from "./errors";
+import { normalizeRole, type Principal } from "./policy";
+
+/**
+ * The single point at which a principal is derived (ADR 0001 section 1).
+ *
+ * Route handlers, server actions, and server components obtain the principal
+ * here. Nothing else calls Clerk's `auth()` and reasons about the result, which
+ * is what stops a handler from inventing its own notion of who is calling.
+ */
+
+/** The authenticated principal, or null when there is no session. */
+export async function getPrincipal(): Promise<Principal | null> {
+  const { userId } = await auth();
+  if (!userId) return null;
+
+  const user = await db.user.findUnique({
+    where: { id: userId },
+    select: { role: true },
+  });
+
+  // Two cases collapse to STUDENT deliberately. A missing row is a real state:
+  // the Clerk webhook that creates it may not have landed yet, and a brand-new
+  // learner must still be able to use the product. An unrecognised role string
+  // is a corrupted row, and least privilege is the safe reading of it. Neither
+  // case may ever produce a role *above* STUDENT.
+  const role = normalizeRole(user?.role) ?? "STUDENT";
+
+  return { userId, role };
+}
+
+/** The authenticated principal, or a denial. Use this at a protected boundary. */
+export async function requirePrincipal(): Promise<Principal> {
+  const principal = await getPrincipal();
+  if (!principal) throw new Denied("unauthenticated");
+  return principal;
+}

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -35,8 +35,6 @@ const serverSchema = z.object({
   STRIPE_API_KEY: nonEmpty,
   STRIPE_WEBHOOK_SECRET: nonEmpty,
 
-  // Optional bootstrap admin (prefer User.role in DB)
-  TEACHER_ID: z.string().optional(),
 });
 
 const clientSchema = z.object({

--- a/lib/roles.ts
+++ b/lib/roles.ts
@@ -1,39 +1,47 @@
-import { db } from "@/lib/db";
+import { can, type Principal, type Role } from "@/lib/auth/policy";
+import { getPrincipal } from "@/lib/auth/principal";
 
-export type UserRole = "STUDENT" | "FACULTY" | "ADMIN";
+/**
+ * @deprecated Use `@/lib/auth` directly.
+ *
+ * These helpers remain only so that call sites can migrate to the centralized
+ * permission module incrementally rather than in one flag-day change. They now
+ * delegate to `lib/auth/policy.ts` and no longer read `process.env.TEACHER_ID`:
+ * privilege comes from `User.role` and nothing else (ADR 0001 section 6).
+ *
+ * Each helper answers "does this role clear the bar", which is exactly the
+ * question that is not sufficient on its own -- it cannot see the resource. New
+ * code must call `requirePrincipal()` and one of the `authorize*` guards so
+ * ownership is asserted in the query. Deleted once every call site has moved.
+ */
+
+export type UserRole = Role;
+
+async function principalFor(userId: string): Promise<Principal | null> {
+  const principal = await getPrincipal();
+  // Defends against a caller passing an id other than the session's. The old
+  // helpers took a userId parameter, so a mismatched value must resolve to no
+  // principal rather than silently authorizing the session's own role.
+  if (!principal || principal.userId !== userId) return null;
+  return principal;
+}
 
 export async function getUserRole(userId: string): Promise<UserRole> {
-  // Fallback: check server-only env var for backward compatibility.
-  // Both sides must be non-empty. `TEACHER_ID` is `z.string().optional()`, so a
-  // blank value is valid configuration, and a blank `userId` is what an
-  // unauthenticated caller produces — comparing them would grant ADMIN to
-  // anonymous requests on any deployment that defines the variable but leaves
-  // it empty. Callers guard with `if (!userId)` today; this makes the grant
-  // safe regardless of whether a future caller remembers to.
-  const teacherId = process.env.TEACHER_ID;
-  if (teacherId && userId && userId === teacherId) {
-    return "ADMIN";
-  }
-
-  const user = await db.user.findUnique({
-    where: { id: userId },
-    select: { role: true },
-  });
-
-  return (user?.role as UserRole) ?? "STUDENT";
+  const principal = await principalFor(userId);
+  return principal?.role ?? "STUDENT";
 }
 
 export async function isAdmin(userId: string): Promise<boolean> {
-  const role = await getUserRole(userId);
-  return role === "ADMIN";
+  const principal = await principalFor(userId);
+  return can(principal, "analytics:read");
 }
 
 export async function isFaculty(userId: string): Promise<boolean> {
-  const role = await getUserRole(userId);
-  return role === "FACULTY" || role === "ADMIN";
+  const principal = await principalFor(userId);
+  return can(principal, "course:create");
 }
 
 export async function isStudent(userId: string): Promise<boolean> {
-  const role = await getUserRole(userId);
-  return role === "STUDENT";
+  const principal = await principalFor(userId);
+  return principal?.role === "STUDENT";
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "db:migrate": "prisma migrate dev",
     "db:studio": "prisma studio",
     "seed": "tsx scripts/seed.ts",
+    "role:grant": "tsx scripts/manage-roles.ts grant",
+    "role:list": "tsx scripts/manage-roles.ts list",
+    "role:check": "tsx scripts/manage-roles.ts check",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "prepare": "husky"

--- a/scripts/manage-roles.ts
+++ b/scripts/manage-roles.ts
@@ -1,0 +1,147 @@
+/**
+ * Role administration from the command line.
+ *
+ * Privilege lives in `User.role` and nothing else grants it. Until #88 ships a
+ * role-management UI, this script is the only way to create the first ADMIN --
+ * and running it is a required pre-flight before the TEACHER_ID removal in #42
+ * reaches production, because a deployment with no ADMIN row cannot be
+ * administered and cannot repair itself.
+ *
+ *   npm run role:grant -- --user user_2abc --role ADMIN
+ *   npm run role:list
+ *   npm run role:check
+ *
+ * See docs/permission-matrix.md and docs/adr/0001-identity-authentication-and-rbac.md.
+ */
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@prisma/client";
+import { config } from "dotenv";
+import { Pool } from "pg";
+
+config();
+config({ path: ".env.local", override: true });
+
+const ROLES = ["STUDENT", "FACULTY", "ADMIN"] as const;
+type Role = (typeof ROLES)[number];
+
+const connectionString = process.env.DATABASE_URL;
+
+if (!connectionString) {
+  console.error(
+    "DATABASE_URL is not set. Add it to .env or .env.local before managing roles."
+  );
+  process.exit(1);
+}
+
+const pool = new Pool({ connectionString });
+const database = new PrismaClient({ adapter: new PrismaPg(pool) });
+
+function flag(name: string): string | undefined {
+  const index = process.argv.indexOf(`--${name}`);
+  return index === -1 ? undefined : process.argv[index + 1];
+}
+
+function isRole(value: string | undefined): value is Role {
+  return ROLES.includes(value as Role);
+}
+
+/** Grants a role. Idempotent: re-running with the same values changes nothing. */
+async function grant(): Promise<number> {
+  const userId = flag("user");
+  const role = flag("role");
+
+  if (!userId) {
+    console.error("Missing --user <clerkUserId>.");
+    return 1;
+  }
+  if (!isRole(role)) {
+    console.error(`Missing or invalid --role. Expected one of: ${ROLES.join(", ")}.`);
+    return 1;
+  }
+
+  const existing = await database.user.findUnique({
+    where: { id: userId },
+    select: { role: true },
+  });
+
+  if (!existing) {
+    // The row is created by the Clerk webhook on first sign-in. Creating one
+    // here would invent a user that Clerk does not know about, so refuse.
+    console.error(
+      `No User row for ${userId}. The user must sign in once so the Clerk ` +
+        `webhook creates their record, then re-run this command.`
+    );
+    return 1;
+  }
+
+  if (existing.role === role) {
+    console.log(`${userId} already has role ${role}. Nothing to do.`);
+    return 0;
+  }
+
+  await database.user.update({ where: { id: userId }, data: { role } });
+  console.log(`${userId}: ${existing.role} -> ${role}`);
+  return 0;
+}
+
+/** Lists everyone holding privilege. Prints ids and roles, never emails. */
+async function list(): Promise<number> {
+  const privileged = await database.user.findMany({
+    where: { role: { in: ["FACULTY", "ADMIN"] } },
+    select: { id: true, role: true },
+    orderBy: [{ role: "asc" }, { id: "asc" }],
+  });
+
+  if (privileged.length === 0) {
+    console.log("No FACULTY or ADMIN users. Administration is unreachable.");
+    return 0;
+  }
+
+  for (const user of privileged) {
+    console.log(`${user.role.padEnd(7)} ${user.id}`);
+  }
+  return 0;
+}
+
+/** Exits non-zero when no ADMIN exists. Intended for a deploy pre-flight. */
+async function check(): Promise<number> {
+  const admins = await database.user.count({ where: { role: "ADMIN" } });
+
+  if (admins === 0) {
+    console.error(
+      "FAIL: no user has role ADMIN. Administration would be unreachable and " +
+        "cannot be granted from inside the application.\n" +
+        "Fix: npm run role:grant -- --user <clerkUserId> --role ADMIN"
+    );
+    return 1;
+  }
+
+  console.log(`OK: ${admins} ADMIN user(s).`);
+  return 0;
+}
+
+const COMMANDS: Record<string, () => Promise<number>> = { grant, list, check };
+
+async function main() {
+  const command = process.argv[2];
+  const run = command ? COMMANDS[command] : undefined;
+
+  if (!run) {
+    console.error(
+      `Usage: tsx scripts/manage-roles.ts <${Object.keys(COMMANDS).join("|")}> [options]`
+    );
+    process.exit(1);
+  }
+
+  process.exitCode = await run();
+}
+
+main()
+  .catch((error) => {
+    console.error(error instanceof Error ? error.message : "Unknown error");
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await database.$disconnect();
+    await pool.end();
+  });

--- a/tests/unit/auth/bootstrap.test.ts
+++ b/tests/unit/auth/bootstrap.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { dbMock } from "../support/db";
+
+vi.mock("@/lib/db", async () => ({ db: (await import("../support/db")).dbMock }));
+
+const { assertAdminExists, countAdmins } = await import("@/lib/auth/bootstrap");
+
+/**
+ * The invariant that makes retiring TEACHER_ID safe.
+ *
+ * Privilege now comes only from `User.role`, and role management is #88, which
+ * does not exist yet. A deployment that reaches production with no ADMIN row
+ * cannot be administered and cannot repair itself from inside the application,
+ * so the count is checked explicitly rather than assumed.
+ */
+describe("countAdmins", () => {
+  it("counts users holding the ADMIN role", async () => {
+    dbMock.user.count.mockResolvedValue(2);
+
+    await expect(countAdmins()).resolves.toBe(2);
+    expect(dbMock.user.count).toHaveBeenCalledWith({ where: { role: "ADMIN" } });
+  });
+});
+
+describe("assertAdminExists", () => {
+  it("passes when at least one ADMIN exists", async () => {
+    dbMock.user.count.mockResolvedValue(1);
+
+    await expect(assertAdminExists()).resolves.toBeUndefined();
+  });
+
+  it("fails loudly when there are none, and names the remedy", async () => {
+    dbMock.user.count.mockResolvedValue(0);
+
+    // The error text is the runbook. Whoever hits this is locked out and needs
+    // the exact command, not a description of the problem.
+    await expect(assertAdminExists()).rejects.toThrow(/no user has role ADMIN/i);
+    await expect(assertAdminExists()).rejects.toThrow(/npm run role:grant/);
+  });
+});

--- a/tests/unit/auth/errors.test.ts
+++ b/tests/unit/auth/errors.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { Denied, isDenied, toResponse } from "@/lib/auth/errors";
+
+/**
+ * The three denial reasons exist because collapsing them loses information the
+ * client needs. Today every handler answers 401, which makes the web app send a
+ * signed-in user to the sign-in page for what is actually a permission error.
+ */
+describe("Denied", () => {
+  it("carries the reason and the action", () => {
+    const denied = new Denied("forbidden", "course:update");
+
+    expect(denied.reason).toBe("forbidden");
+    expect(denied.action).toBe("course:update");
+    expect(denied).toBeInstanceOf(Error);
+    expect(denied.name).toBe("Denied");
+  });
+
+  it("names the action in the message but never the resource or principal", () => {
+    // The message reaches server logs. Ids of resources and people do not
+    // belong there.
+    expect(new Denied("not_found", "quiz:delete").message).toBe("denied: not_found (quiz:delete)");
+    expect(new Denied("unauthenticated").message).toBe("denied: unauthenticated");
+  });
+});
+
+describe("isDenied", () => {
+  it("recognises a denial and nothing else", () => {
+    expect(isDenied(new Denied("forbidden"))).toBe(true);
+    for (const other of [new Error("boom"), null, undefined, "forbidden", {}, { reason: "forbidden" }]) {
+      expect(isDenied(other)).toBe(false);
+    }
+  });
+});
+
+describe("toResponse", () => {
+  it.each([
+    ["unauthenticated", 401, "Unauthorized"],
+    ["forbidden", 403, "Forbidden"],
+    ["not_found", 404, "Not Found"],
+  ] as const)("maps %s to %i", async (reason, status, body) => {
+    const response = toResponse(new Denied(reason));
+
+    expect(response?.status).toBe(status);
+    await expect(response?.text()).resolves.toBe(body);
+  });
+
+  it("returns null for anything that is not a denial", () => {
+    // A handler's catch block re-raises genuine faults rather than reporting an
+    // internal error as a permission problem.
+    for (const other of [new Error("connection reset"), null, undefined, "nope"]) {
+      expect(toResponse(other)).toBeNull();
+    }
+  });
+});

--- a/tests/unit/auth/guards.test.ts
+++ b/tests/unit/auth/guards.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Principal } from "@/lib/auth/policy";
+import { dbMock } from "../support/db";
+
+vi.mock("@/lib/db", async () => ({ db: (await import("../support/db")).dbMock }));
+
+const {
+  authorizeComment,
+  authorizeCourse,
+  authorizeModuleInCourse,
+  authorizePost,
+  requireCapability,
+} = await import("@/lib/auth/guards");
+const { Denied } = await import("@/lib/auth/errors");
+
+/**
+ * The guards exist to make ADR 0001 section 4 structural: the ownership
+ * condition goes *inside* the query that loads the resource, so there is no
+ * moment at which an unrelated row has been read and might be returned. The
+ * assertions below therefore check the emitted `where` clause, not just the
+ * return value -- a guard that filtered in JavaScript after an unfiltered read
+ * would pass a return-value test and still be wrong.
+ */
+const faculty: Principal = { userId: "user_owner", role: "FACULTY" };
+const student: Principal = { userId: "user_owner", role: "STUDENT" };
+const admin: Principal = { userId: "user_admin", role: "ADMIN" };
+
+async function reasonFor(promise: Promise<unknown>): Promise<string> {
+  try {
+    await promise;
+    throw new Error("expected the guard to deny");
+  } catch (error) {
+    if (error instanceof Denied) return error.reason;
+    throw error;
+  }
+}
+
+describe("requireCapability", () => {
+  it("passes for a role holding the capability", () => {
+    expect(() => requireCapability(admin, "analytics:read")).not.toThrow();
+    expect(() => requireCapability(faculty, "course:create")).not.toThrow();
+  });
+
+  it("denies as forbidden, not as not_found, for the wrong role", () => {
+    // The distinction matters: 403 tells the client the request was understood
+    // and refused, so it does not bounce the user to a sign-in page.
+    expect(() => requireCapability(faculty, "analytics:read")).toThrow(Denied);
+    try {
+      requireCapability(student, "course:create");
+    } catch (error) {
+      expect((error as InstanceType<typeof Denied>).reason).toBe("forbidden");
+    }
+  });
+});
+
+describe("authorizeCourse", () => {
+  beforeEach(() => {
+    dbMock.course.findFirst.mockResolvedValue({ id: "course_1", userId: "user_owner" });
+  });
+
+  it("returns the Course when the principal owns it", async () => {
+    await expect(authorizeCourse(faculty, "course:update", "course_1")).resolves.toMatchObject({
+      id: "course_1",
+    });
+  });
+
+  it("asserts ownership inside the query rather than after it", async () => {
+    await authorizeCourse(faculty, "course:update", "course_1");
+
+    expect(dbMock.course.findFirst).toHaveBeenCalledWith({
+      where: { id: "course_1", userId: "user_owner" },
+    });
+  });
+
+  it("refuses the wrong role before touching the database", async () => {
+    expect(await reasonFor(authorizeCourse(student, "course:update", "course_1"))).toBe("forbidden");
+    expect(dbMock.course.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("reports a Course owned by someone else as not_found", async () => {
+    // The ownership filter means the row simply does not come back. Answering
+    // 403 here would confirm the Course exists and turn the endpoint into an
+    // oracle for enumerating other people's Courses.
+    dbMock.course.findFirst.mockResolvedValue(null);
+
+    expect(await reasonFor(authorizeCourse(faculty, "course:update", "course_1"))).toBe("not_found");
+  });
+
+  it("reports a Course that does not exist the same way", async () => {
+    dbMock.course.findFirst.mockResolvedValue(null);
+
+    expect(await reasonFor(authorizeCourse(faculty, "course:delete", "missing"))).toBe("not_found");
+  });
+
+  it("does not exempt an ADMIN from ownership", async () => {
+    dbMock.course.findFirst.mockResolvedValue(null);
+
+    expect(await reasonFor(authorizeCourse(admin, "course:delete", "course_1"))).toBe("not_found");
+    expect(dbMock.course.findFirst).toHaveBeenCalledWith({
+      where: { id: "course_1", userId: "user_admin" },
+    });
+  });
+});
+
+describe("authorizeModuleInCourse", () => {
+  beforeEach(() => {
+    dbMock.module.findFirst.mockResolvedValue({ id: "module_1", courseId: "course_1" });
+  });
+
+  it("asserts the full Course to Module relationship and both ownership paths", async () => {
+    await authorizeModuleInCourse(faculty, "topic:update", "course_1", "module_1");
+
+    // Binding `courseId` in the same query is what stops a Module id belonging
+    // to a different Course from being smuggled through the route parameter.
+    expect(dbMock.module.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: "module_1",
+        courseId: "course_1",
+        OR: [{ course: { userId: "user_owner" } }, { facultyId: "user_owner" }],
+      },
+    });
+  });
+
+  it("refuses the wrong role before touching the database", async () => {
+    expect(
+      await reasonFor(authorizeModuleInCourse(student, "topic:update", "course_1", "module_1"))
+    ).toBe("forbidden");
+    expect(dbMock.module.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("reports a Module in another Course as not_found", async () => {
+    dbMock.module.findFirst.mockResolvedValue(null);
+
+    expect(
+      await reasonFor(authorizeModuleInCourse(faculty, "topic:update", "course_1", "module_9"))
+    ).toBe("not_found");
+  });
+});
+
+describe("authorizePost and authorizeComment", () => {
+  it("allows an author to act on their own post", async () => {
+    dbMock.forumPost.findUnique.mockResolvedValue({ id: "post_1", userId: "user_owner" });
+
+    await expect(authorizePost(student, "post:update", "post_1")).resolves.toMatchObject({
+      id: "post_1",
+    });
+  });
+
+  it("refuses a non-author who is not a moderator", async () => {
+    dbMock.forumPost.findUnique.mockResolvedValue({ id: "post_1", userId: "someone_else" });
+
+    expect(await reasonFor(authorizePost(student, "post:delete", "post_1"))).toBe("forbidden");
+  });
+
+  it("allows a moderator to act on anyone's post", async () => {
+    dbMock.forumPost.findUnique.mockResolvedValue({ id: "post_1", userId: "someone_else" });
+
+    await expect(authorizePost(admin, "post:delete", "post_1")).resolves.toMatchObject({
+      id: "post_1",
+    });
+  });
+
+  it("reports a missing post as not_found", async () => {
+    dbMock.forumPost.findUnique.mockResolvedValue(null);
+
+    expect(await reasonFor(authorizePost(admin, "post:delete", "missing"))).toBe("not_found");
+  });
+
+  it("applies the same rules to comments", async () => {
+    dbMock.forumComment.findUnique.mockResolvedValue({ id: "c1", userId: "someone_else" });
+    expect(await reasonFor(authorizeComment(student, "comment:delete", "c1"))).toBe("forbidden");
+
+    await expect(authorizeComment(admin, "comment:delete", "c1")).resolves.toMatchObject({ id: "c1" });
+
+    dbMock.forumComment.findUnique.mockResolvedValue(null);
+    expect(await reasonFor(authorizeComment(admin, "comment:delete", "c1"))).toBe("not_found");
+  });
+});

--- a/tests/unit/auth/policy.test.ts
+++ b/tests/unit/auth/policy.test.ts
@@ -1,0 +1,322 @@
+import { describe, expect, it } from "vitest";
+
+import { ACTIONS, isAction, type Action } from "@/lib/auth/actions";
+import {
+  can,
+  normalizeRole,
+  type Principal,
+  type Resource,
+  type Role,
+} from "@/lib/auth/policy";
+
+/**
+ * The permission matrix.
+ *
+ * `can` is pure, so every combination is cheap and the matrix is covered
+ * exhaustively rather than sampled. The suite is written deny-first: for each
+ * action it names the one principal that should be allowed and then asserts
+ * that every other principal is refused, because the failure that matters is a
+ * guard that does not hold, not a feature that does not work.
+ *
+ * Implements ADR 0001. Documented in docs/permission-matrix.md.
+ */
+
+const OWNER = "user_owner";
+const OTHER = "user_other";
+const ASSIGNED = "user_assigned";
+
+const asRole = (role: Role, userId = OWNER): Principal => ({ userId, role });
+
+const student = asRole("STUDENT");
+const faculty = asRole("FACULTY");
+const admin = asRole("ADMIN");
+const otherFaculty = asRole("FACULTY", OTHER);
+const otherAdmin = asRole("ADMIN", OTHER);
+
+const ownedCourse: Resource = { kind: "course", ownerId: OWNER };
+const otherCourse: Resource = { kind: "course", ownerId: OTHER };
+
+/** Classification of every action, so the tests below can be exhaustive. */
+const ADMIN_ONLY: Action[] = [
+  "community:moderate",
+  "analytics:read",
+  "learner:administer",
+  "role:manage",
+];
+const FACULTY_GLOBAL: Action[] = ["course:create", "upload:courseAsset"];
+const AUTHOR_OR_MODERATOR: Action[] = [
+  "post:update",
+  "post:delete",
+  "comment:update",
+  "comment:delete",
+];
+const ACTIVE_ENROLLMENT: Action[] = ["course:learn"];
+const RESERVED: Action[] = ["billing:administer", "ai:administer"];
+const FACULTY_OWNED: Action[] = ACTIONS.filter(
+  (action) =>
+    !ADMIN_ONLY.includes(action) &&
+    !FACULTY_GLOBAL.includes(action) &&
+    !AUTHOR_OR_MODERATOR.includes(action) &&
+    !ACTIVE_ENROLLMENT.includes(action) &&
+    !RESERVED.includes(action)
+);
+
+describe("the matrix is total", () => {
+  it("classifies every action in the vocabulary exactly once", () => {
+    const classified = [
+      ...ADMIN_ONLY,
+      ...FACULTY_GLOBAL,
+      ...AUTHOR_OR_MODERATOR,
+      ...ACTIVE_ENROLLMENT,
+      ...RESERVED,
+      ...FACULTY_OWNED,
+    ];
+
+    // If a new action is added without a test classification, this fails --
+    // which is the point. An unclassified action would otherwise slip through
+    // the exhaustive suites below untested.
+    expect(classified.slice().sort()).toEqual(ACTIONS.slice().sort());
+    expect(new Set(classified).size).toBe(ACTIONS.length);
+  });
+});
+
+describe("ADMIN-only actions", () => {
+  for (const action of ADMIN_ONLY) {
+    it(`allows ADMIN and refuses everyone else for ${action}`, () => {
+      expect(can(admin, action)).toBe(true);
+      expect(can(faculty, action)).toBe(false);
+      expect(can(student, action)).toBe(false);
+    });
+
+    it(`ignores ownership for ${action}`, () => {
+      // These are global powers. Owning a Course must neither grant nor
+      // withhold them.
+      expect(can(otherAdmin, action, otherCourse)).toBe(true);
+      expect(can(otherFaculty, action, ownedCourse)).toBe(false);
+    });
+  }
+});
+
+describe("faculty actions that need no resource", () => {
+  for (const action of FACULTY_GLOBAL) {
+    it(`allows FACULTY and ADMIN but refuses STUDENT for ${action}`, () => {
+      expect(can(faculty, action)).toBe(true);
+      expect(can(admin, action)).toBe(true);
+      expect(can(student, action)).toBe(false);
+    });
+  }
+});
+
+describe("authoring actions require ownership", () => {
+  for (const action of FACULTY_OWNED) {
+    it(`allows the owning FACULTY for ${action}`, () => {
+      expect(can(faculty, action, ownedCourse)).toBe(true);
+    });
+
+    it(`refuses a FACULTY who does not own the Course for ${action}`, () => {
+      expect(can(otherFaculty, action, ownedCourse)).toBe(false);
+      expect(can(faculty, action, otherCourse)).toBe(false);
+    });
+
+    it(`refuses an ADMIN who does not own the Course for ${action}`, () => {
+      // The approved decision for #42: ownership is required for authoring even
+      // for ADMIN, matching what DELETE /api/courses/[courseId] enforces today.
+      // Widening this is #86's call, and this test is what makes that a
+      // deliberate change rather than a drift.
+      expect(can(admin, action, ownedCourse)).toBe(true);
+      expect(can(otherAdmin, action, ownedCourse)).toBe(false);
+    });
+
+    it(`refuses a STUDENT who somehow owns the Course for ${action}`, () => {
+      // Ownership never substitutes for the role.
+      expect(can(asRole("STUDENT", OWNER), action, ownedCourse)).toBe(false);
+    });
+
+    it(`refuses ${action} when no resource is supplied`, () => {
+      // Defaulting to the global resource must not accidentally satisfy an
+      // ownership rule.
+      expect(can(faculty, action)).toBe(false);
+      expect(can(admin, action)).toBe(false);
+    });
+  }
+});
+
+describe("Module ownership", () => {
+  const moduleOwnedViaCourse: Resource = {
+    kind: "module",
+    courseOwnerId: OWNER,
+    assignedFacultyId: null,
+  };
+  const moduleAssigned: Resource = {
+    kind: "module",
+    courseOwnerId: OTHER,
+    assignedFacultyId: ASSIGNED,
+  };
+
+  it("grants the Course creator", () => {
+    expect(can(faculty, "topic:update", moduleOwnedViaCourse)).toBe(true);
+  });
+
+  it("grants the assigned faculty member of a Course they did not create", () => {
+    // Assigned teaching is modelled separately from global administration,
+    // which is the distinction #42 requires.
+    expect(can(asRole("FACULTY", ASSIGNED), "topic:update", moduleAssigned)).toBe(true);
+  });
+
+  it("refuses a faculty member who is neither creator nor assignee", () => {
+    expect(can(asRole("FACULTY", "user_stranger"), "topic:update", moduleAssigned)).toBe(false);
+  });
+
+  it("does not treat an unassigned Module as owned by an unrelated faculty member", () => {
+    // `assignedFacultyId` is nullable. An unassigned Module belongs to its
+    // Course creator and to nobody else.
+    expect(
+      can(asRole("FACULTY", "user_stranger"), "topic:update", {
+        kind: "module",
+        courseOwnerId: OTHER,
+        assignedFacultyId: null,
+      })
+    ).toBe(false);
+
+    expect(
+      can(asRole("FACULTY", OTHER), "topic:update", {
+        kind: "module",
+        courseOwnerId: OTHER,
+        assignedFacultyId: null,
+      })
+    ).toBe(true);
+  });
+});
+
+describe("author-or-moderator actions", () => {
+  const mine: Resource = { kind: "authored", authorId: OWNER };
+  const theirs: Resource = { kind: "authored", authorId: OTHER };
+
+  for (const action of AUTHOR_OR_MODERATOR) {
+    it(`allows the author for ${action}`, () => {
+      expect(can(student, action, mine)).toBe(true);
+    });
+
+    it(`refuses a non-author who is not a moderator for ${action}`, () => {
+      expect(can(student, action, theirs)).toBe(false);
+      expect(can(faculty, action, theirs)).toBe(false);
+    });
+
+    it(`allows ADMIN to act on anyone's content for ${action}`, () => {
+      expect(can(otherAdmin, action, theirs)).toBe(true);
+    });
+
+    it(`refuses ${action} when the resource is not authored content`, () => {
+      expect(can(student, action, ownedCourse)).toBe(false);
+      expect(can(student, action)).toBe(false);
+    });
+
+    it(`does not match an empty author id for ${action}`, () => {
+      // A real principal against content with no recorded author. The empty
+      // *principal* id is covered by the deny-by-default block below; this is
+      // the other half of the pair.
+      expect(can(student, action, { kind: "authored", authorId: "" })).toBe(false);
+    });
+  }
+});
+
+describe("learner access to Course content", () => {
+  for (const action of ACTIVE_ENROLLMENT) {
+    it.each(["ACTIVE", "COMPLETED"])(`allows a %s Enrollment for ${action}`, (status) => {
+      expect(can(student, action, { kind: "enrollment", status })).toBe(true);
+    });
+
+    it(`refuses a SUSPENDED Enrollment for ${action}`, () => {
+      expect(can(student, action, { kind: "enrollment", status: "SUSPENDED" })).toBe(false);
+      // Privilege does not buy back a suspension.
+      expect(can(admin, action, { kind: "enrollment", status: "SUSPENDED" })).toBe(false);
+    });
+
+    it(`refuses an unrecognised Enrollment status for ${action}`, () => {
+      for (const status of ["", "active", "PENDING", "REFUNDED"]) {
+        expect(can(student, action, { kind: "enrollment", status })).toBe(false);
+      }
+    });
+
+    it(`refuses ${action} when no Enrollment is supplied`, () => {
+      expect(can(student, action)).toBe(false);
+      expect(can(student, action, ownedCourse)).toBe(false);
+    });
+  }
+});
+
+describe("reserved actions", () => {
+  for (const action of RESERVED) {
+    it(`refuses every role for ${action} until its owning issue implements it`, () => {
+      for (const principal of [student, faculty, admin]) {
+        expect(can(principal, action)).toBe(false);
+        expect(can(principal, action, ownedCourse)).toBe(false);
+      }
+    });
+  }
+});
+
+describe("deny by default", () => {
+  it("refuses an absent principal for every action", () => {
+    for (const action of ACTIONS) {
+      expect(can(null, action, ownedCourse)).toBe(false);
+      expect(can(undefined, action, ownedCourse)).toBe(false);
+    }
+  });
+
+  it("refuses a principal with an empty user id for every action", () => {
+    // An unauthenticated caller produces an empty id. It must never match an
+    // owner id, including an owner id that is itself empty.
+    for (const action of ACTIONS) {
+      expect(can({ userId: "", role: "ADMIN" }, action, { kind: "course", ownerId: "" })).toBe(false);
+    }
+  });
+
+  it("refuses a role the domain does not define", () => {
+    for (const corrupt of ["admin", "Admin", "SUPERUSER", "", " ADMIN ", 1, true, null, {}, []]) {
+      const principal = { userId: OWNER, role: corrupt } as unknown as Principal;
+      expect(can(principal, "analytics:read")).toBe(false);
+      expect(can(principal, "course:update", ownedCourse)).toBe(false);
+      expect(can(principal, "course:learn", { kind: "enrollment", status: "ACTIVE" })).toBe(false);
+    }
+  });
+
+  it("refuses an action outside the vocabulary", () => {
+    for (const unknown of ["course:destroy", "", "COURSE:UPDATE", "__proto__", "toString"]) {
+      expect(can(admin, unknown as Action, ownedCourse)).toBe(false);
+    }
+  });
+
+  it("does not resolve actions through the prototype chain", () => {
+    // `RULES` is an object literal. Without a guard, `can(p, "toString")` could
+    // find Object.prototype.toString and take an unintended branch.
+    expect(can(admin, "constructor" as Action)).toBe(false);
+    expect(can(admin, "hasOwnProperty" as Action)).toBe(false);
+  });
+});
+
+describe("normalizeRole", () => {
+  it("accepts exactly the three defined roles", () => {
+    expect(normalizeRole("STUDENT")).toBe("STUDENT");
+    expect(normalizeRole("FACULTY")).toBe("FACULTY");
+    expect(normalizeRole("ADMIN")).toBe("ADMIN");
+  });
+
+  it("rejects everything else", () => {
+    for (const value of ["admin", "Faculty", " ADMIN", "", null, undefined, 0, {}, []]) {
+      expect(normalizeRole(value)).toBeNull();
+    }
+  });
+});
+
+describe("isAction", () => {
+  it("accepts every member of the vocabulary", () => {
+    for (const action of ACTIONS) expect(isAction(action)).toBe(true);
+  });
+
+  it("rejects non-members, non-strings, and inherited properties", () => {
+    for (const value of ["course:destroy", "", 1, null, undefined, {}, "toString", "__proto__"]) {
+      expect(isAction(value)).toBe(false);
+    }
+  });
+});

--- a/tests/unit/auth/principal.test.ts
+++ b/tests/unit/auth/principal.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { dbMock } from "../support/db";
+
+const clerkAuth = vi.hoisted(() => vi.fn());
+vi.mock("@clerk/nextjs/server", () => ({ auth: clerkAuth }));
+vi.mock("@/lib/db", async () => ({ db: (await import("../support/db")).dbMock }));
+
+const { getPrincipal, requirePrincipal } = await import("@/lib/auth/principal");
+const { Denied } = await import("@/lib/auth/errors");
+
+/**
+ * Principal derivation is the one place identity enters the application
+ * (ADR 0001 section 1). Every test here is about what happens when the session
+ * or the stored role is something other than the happy path, because those are
+ * the states that decide whether a corrupted row becomes a privilege.
+ */
+function signedInAs(userId: string | null) {
+  clerkAuth.mockResolvedValue({ userId });
+}
+
+beforeEach(() => {
+  signedInAs("user_1");
+});
+
+describe("getPrincipal", () => {
+  it("pairs the Clerk user id with the role stored on the User row", async () => {
+    dbMock.user.findUnique.mockResolvedValue({ role: "FACULTY" });
+
+    await expect(getPrincipal()).resolves.toEqual({
+      userId: "user_1",
+      role: "FACULTY",
+    });
+  });
+
+  it("returns no principal when there is no session", async () => {
+    signedInAs(null);
+
+    await expect(getPrincipal()).resolves.toBeNull();
+    // The database must not be consulted for an anonymous caller.
+    expect(dbMock.user.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("selects only the role for the session's own user", async () => {
+    dbMock.user.findUnique.mockResolvedValue({ role: "ADMIN" });
+
+    await getPrincipal();
+
+    expect(dbMock.user.findUnique).toHaveBeenCalledWith({
+      where: { id: "user_1" },
+      select: { role: true },
+    });
+  });
+
+  it("falls back to STUDENT when the User row does not exist yet", async () => {
+    // Real state: the Clerk webhook that creates the row may not have landed.
+    // A new learner must still be able to use the product.
+    dbMock.user.findUnique.mockResolvedValue(null);
+
+    await expect(getPrincipal()).resolves.toEqual({
+      userId: "user_1",
+      role: "STUDENT",
+    });
+  });
+
+  it("never derives a role above STUDENT from a corrupted row", async () => {
+    for (const corrupt of ["admin", "Admin", "SUPERUSER", " ADMIN ", "", null, 1, true, {}, []]) {
+      dbMock.user.findUnique.mockResolvedValue({ role: corrupt });
+
+      await expect(getPrincipal()).resolves.toEqual({
+        userId: "user_1",
+        role: "STUDENT",
+      });
+    }
+  });
+
+  it("propagates a database failure instead of assuming a role", async () => {
+    dbMock.user.findUnique.mockRejectedValue(new Error("connection reset"));
+
+    // Swallowing this and returning STUDENT would turn an outage into a silent
+    // authorization decision that happens to look like a working product.
+    await expect(getPrincipal()).rejects.toThrow("connection reset");
+  });
+});
+
+describe("requirePrincipal", () => {
+  it("returns the principal when there is a session", async () => {
+    dbMock.user.findUnique.mockResolvedValue({ role: "ADMIN" });
+
+    await expect(requirePrincipal()).resolves.toEqual({
+      userId: "user_1",
+      role: "ADMIN",
+    });
+  });
+
+  it("denies as unauthenticated when there is no session", async () => {
+    signedInAs(null);
+
+    await expect(requirePrincipal()).rejects.toBeInstanceOf(Denied);
+    await expect(requirePrincipal()).rejects.toMatchObject({
+      reason: "unauthenticated",
+    });
+  });
+});

--- a/tests/unit/roles.test.ts
+++ b/tests/unit/roles.test.ts
@@ -1,171 +1,115 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { dbMock } from "./support/db";
-import { aRoleRow } from "./support/builders";
 
-vi.mock("@/lib/db", async () => ({
-  db: (await import("./support/db")).dbMock,
-}));
+const clerkAuth = vi.hoisted(() => vi.fn());
+vi.mock("@clerk/nextjs/server", () => ({ auth: clerkAuth }));
+vi.mock("@/lib/db", async () => ({ db: (await import("./support/db")).dbMock }));
 
 const { getUserRole, isAdmin, isFaculty, isStudent } = await import("@/lib/roles");
 
 /**
- * Authorization is the invariant with the worst failure mode in the product: a
- * wrong answer here exposes another learner's data or hands out privilege. The
- * tests below therefore assert the *deny* direction as carefully as the grant
- * direction, and cover the boundaries between the three roles exhaustively.
+ * `lib/roles.ts` is now a deprecated adapter over `lib/auth`, kept only so call
+ * sites can migrate incrementally. These tests pin the two properties that
+ * matter while it still exists:
  *
- * Related work: #42 replaces this module with a centralized RBAC and ownership
- * module. These tests describe the behaviour that must survive that move.
+ *   1. It answers the same questions it always did, so migrating a call site is
+ *      a refactor rather than a behaviour change.
+ *   2. TEACHER_ID grants nothing. That is the regression proving ADR 0001
+ *      section 6 -- the environment backdoor is removed, not deprecated.
+ *
+ * The exhaustive matrix lives in tests/unit/auth/policy.test.ts. This file is
+ * deleted along with the adapter when the last call site moves.
  */
-describe("getUserRole", () => {
-  beforeEach(() => {
-    delete process.env.TEACHER_ID;
+beforeEach(() => {
+  clerkAuth.mockResolvedValue({ userId: "user_1" });
+});
+
+describe("the deprecated role adapter", () => {
+  it.each([
+    ["ADMIN", true, true, false],
+    ["FACULTY", false, true, false],
+    ["STUDENT", false, false, true],
+  ])("resolves %s consistently", async (role, admin, faculty, studentOnly) => {
+    dbMock.user.findUnique.mockResolvedValue({ role });
+
+    await expect(getUserRole("user_1")).resolves.toBe(role);
+    await expect(isAdmin("user_1")).resolves.toBe(admin);
+    await expect(isFaculty("user_1")).resolves.toBe(faculty);
+    await expect(isStudent("user_1")).resolves.toBe(studentOnly);
   });
 
-  it("returns the role persisted on the User row", async () => {
-    dbMock.user.findUnique.mockResolvedValue(aRoleRow("FACULTY"));
-
-    await expect(getUserRole("user_1")).resolves.toBe("FACULTY");
-  });
-
-  it("reads the role for the requested user and selects nothing else", async () => {
-    dbMock.user.findUnique.mockResolvedValue(aRoleRow("ADMIN"));
-
-    await getUserRole("user_42");
-
-    expect(dbMock.user.findUnique).toHaveBeenCalledWith({
-      where: { id: "user_42" },
-      select: { role: true },
-    });
-  });
-
-  it("defaults an unknown user to STUDENT rather than throwing", async () => {
+  it("defaults an unknown user to STUDENT", async () => {
     dbMock.user.findUnique.mockResolvedValue(null);
 
-    await expect(getUserRole("ghost")).resolves.toBe("STUDENT");
+    await expect(getUserRole("user_1")).resolves.toBe("STUDENT");
+    await expect(isAdmin("user_1")).resolves.toBe(false);
+    await expect(isFaculty("user_1")).resolves.toBe(false);
   });
 
-  it("defaults to STUDENT when the row exists but the role is null", async () => {
-    dbMock.user.findUnique.mockResolvedValue({ role: null });
+  it("grants nothing for a role the domain does not define", async () => {
+    for (const corrupt of ["admin", "Admin", "SUPERUSER", "", 1, true, {}, []]) {
+      dbMock.user.findUnique.mockResolvedValue({ role: corrupt });
 
+      await expect(isAdmin("user_1")).resolves.toBe(false);
+      await expect(isFaculty("user_1")).resolves.toBe(false);
+    }
+  });
+
+  it("grants nothing when there is no session", async () => {
+    clerkAuth.mockResolvedValue({ userId: null });
+
+    await expect(isAdmin("user_1")).resolves.toBe(false);
+    await expect(isFaculty("user_1")).resolves.toBe(false);
+    await expect(isStudent("user_1")).resolves.toBe(false);
     await expect(getUserRole("user_1")).resolves.toBe("STUDENT");
   });
 
-  describe("the TEACHER_ID environment backdoor", () => {
-    /**
-     * `lib/roles.ts` grants ADMIN to whoever matches `process.env.TEACHER_ID`,
-     * bypassing the database entirely. The matrix flags this as the reason row
-     * 1.7 is `partial`, and #42 removes it. Until then it is real production
-     * behaviour and is pinned here so its removal is a deliberate, visible
-     * change rather than an accident.
-     */
-    it("grants ADMIN on an exact match without consulting the database", async () => {
-      vi.stubEnv("TEACHER_ID", "teacher_1");
+  it("ignores a userId that is not the session's own", async () => {
+    // The old signature accepted any userId. A caller passing someone else's id
+    // must not receive an answer derived from the session's role.
+    dbMock.user.findUnique.mockResolvedValue({ role: "ADMIN" });
 
-      await expect(getUserRole("teacher_1")).resolves.toBe("ADMIN");
-      expect(dbMock.user.findUnique).not.toHaveBeenCalled();
-    });
-
-    it("does not grant ADMIN on a near match", async () => {
-      vi.stubEnv("TEACHER_ID", "teacher_1");
-      dbMock.user.findUnique.mockResolvedValue(aRoleRow("STUDENT"));
-
-      await expect(getUserRole("teacher_10")).resolves.toBe("STUDENT");
-      await expect(getUserRole("Teacher_1")).resolves.toBe("STUDENT");
-      await expect(getUserRole(" teacher_1")).resolves.toBe("STUDENT");
-    });
-
-    it("does not grant ADMIN to an empty user id when TEACHER_ID is unset", async () => {
-      // `undefined === ""` is false, so this must fall through to the database.
-      // If the comparison were ever loosened, an anonymous caller would become
-      // an administrator on any deployment that forgot to set TEACHER_ID.
-      dbMock.user.findUnique.mockResolvedValue(null);
-
-      await expect(getUserRole("")).resolves.toBe("STUDENT");
-      expect(dbMock.user.findUnique).toHaveBeenCalled();
-    });
-  });
-});
-
-describe("role predicates", () => {
-  const cases: Array<{
-    persisted: string | null;
-    admin: boolean;
-    faculty: boolean;
-    student: boolean;
-  }> = [
-    { persisted: "ADMIN", admin: true, faculty: true, student: false },
-    { persisted: "FACULTY", admin: false, faculty: true, student: false },
-    { persisted: "STUDENT", admin: false, faculty: false, student: true },
-    // Absent or unrecognised state must resolve to the least privilege.
-    { persisted: null, admin: false, faculty: false, student: true },
-  ];
-
-  for (const { persisted, admin, faculty, student } of cases) {
-    it(`resolves ${persisted ?? "an absent user"} to admin=${admin} faculty=${faculty} student=${student}`, async () => {
-      dbMock.user.findUnique.mockResolvedValue(aRoleRow(persisted));
-
-      await expect(isAdmin("user_1")).resolves.toBe(admin);
-      await expect(isFaculty("user_1")).resolves.toBe(faculty);
-      await expect(isStudent("user_1")).resolves.toBe(student);
-    });
-  }
-
-  it("treats ADMIN as a superset of FACULTY but never of STUDENT", async () => {
-    dbMock.user.findUnique.mockResolvedValue(aRoleRow("ADMIN"));
-
-    await expect(isFaculty("user_1")).resolves.toBe(true);
-    await expect(isStudent("user_1")).resolves.toBe(false);
-  });
-});
-
-/**
- * Deliberate fault injection.
- *
- * Coverage percentages prove a line ran, not that it was checked. These cases
- * corrupt the module's only dependency and assert the deny-by-default contract
- * still holds — the property that actually protects learner data.
- */
-describe("fault injection at the persistence boundary", () => {
-  it("denies privilege for role values the domain does not define", async () => {
-    for (const corrupt of ["admin", "Admin", "SUPERUSER", "", "  ADMIN  "]) {
-      dbMock.user.findUnique.mockResolvedValue({ role: corrupt });
-
-      await expect(isAdmin("user_1")).resolves.toBe(false);
-      await expect(isFaculty("user_1")).resolves.toBe(false);
-    }
+    await expect(isAdmin("someone_else")).resolves.toBe(false);
+    await expect(getUserRole("someone_else")).resolves.toBe("STUDENT");
   });
 
-  it("denies privilege when the role arrives as a non-string", async () => {
-    for (const corrupt of [0, 1, true, {}, []]) {
-      dbMock.user.findUnique.mockResolvedValue({ role: corrupt });
-
-      await expect(isAdmin("user_1")).resolves.toBe(false);
-      await expect(isFaculty("user_1")).resolves.toBe(false);
-    }
-  });
-
-  it("does not grant ADMIN through type coercion at an untyped call site", async () => {
-    // TypeScript types `userId` as a string, but route handlers receive values
-    // that TypeScript never checked. If the identity comparison were ever
-    // loosened from `===` to `==`, an empty TEACHER_ID plus a coercible caller
-    // value (`[]`, `""`) would loosely compare equal and mint an administrator.
-    vi.stubEnv("TEACHER_ID", "");
-    dbMock.user.findUnique.mockResolvedValue(aRoleRow("STUDENT"));
-
-    for (const coercible of [[], "", 0, false, null, undefined]) {
-      await expect(
-        isAdmin(coercible as unknown as string)
-      ).resolves.toBe(false);
-    }
-  });
-
-  it("fails closed by propagating a database error instead of granting access", async () => {
+  it("propagates a database failure instead of granting access", async () => {
     dbMock.user.findUnique.mockRejectedValue(new Error("connection reset"));
 
-    // The caller must see the failure. Swallowing it and returning a default
-    // role would turn an outage into a silent authorization decision.
     await expect(isAdmin("user_1")).rejects.toThrow("connection reset");
+  });
+
+  describe("TEACHER_ID is retired", () => {
+    it("grants nothing when the environment variable matches the caller", async () => {
+      // The regression for ADR 0001 section 6. Before #42 this returned ADMIN
+      // without consulting the database at all.
+      vi.stubEnv("TEACHER_ID", "user_1");
+      dbMock.user.findUnique.mockResolvedValue({ role: "STUDENT" });
+
+      await expect(getUserRole("user_1")).resolves.toBe("STUDENT");
+      await expect(isAdmin("user_1")).resolves.toBe(false);
+      await expect(isFaculty("user_1")).resolves.toBe(false);
+    });
+
+    it("consults the database rather than the environment", async () => {
+      vi.stubEnv("TEACHER_ID", "user_1");
+      dbMock.user.findUnique.mockResolvedValue({ role: "STUDENT" });
+
+      await isAdmin("user_1");
+
+      expect(dbMock.user.findUnique).toHaveBeenCalledWith({
+        where: { id: "user_1" },
+        select: { role: true },
+      });
+    });
+
+    it("cannot be exploited with an empty variable and an empty caller", async () => {
+      vi.stubEnv("TEACHER_ID", "");
+      clerkAuth.mockResolvedValue({ userId: "" });
+
+      await expect(isAdmin("")).resolves.toBe(false);
+      await expect(isFaculty("")).resolves.toBe(false);
+    });
   });
 });

--- a/tests/unit/support/setup.ts
+++ b/tests/unit/support/setup.ts
@@ -15,9 +15,10 @@ import { resetDbMock } from "./db";
 // Individual tests move the clock with `freezeTimeAt()` from ./time.
 process.env.TZ = "UTC";
 
-// `lib/roles.ts` grants ADMIN to `process.env.TEACHER_ID`. If a developer has
-// that set in a local shell, authorization tests would pass for the wrong
-// reason. Clear it; the tests that care set it explicitly.
+// TEACHER_ID was retired in #42 and now grants nothing, but a stale value in a
+// developer's shell would still make the regression that proves this pass for
+// the wrong reason. Clear it; the tests that assert its irrelevance set it
+// explicitly.
 delete process.env.TEACHER_ID;
 
 const REAL_RANDOM = Math.random;

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -20,6 +20,13 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": fileURLToPath(new URL("./", import.meta.url)),
+      // `server-only` is a marker package: outside a React Server Component
+      // condition its entry point throws by design. Point it at the package's
+      // own empty build so a server-only module can be unit tested, while the
+      // Next.js build keeps enforcing the real boundary.
+      "server-only": fileURLToPath(
+        new URL("./node_modules/server-only/empty.js", import.meta.url)
+      ),
     },
   },
   test: {
@@ -39,6 +46,7 @@ export default defineConfig({
       reporter: ["text-summary", "lcov", "html"],
       reportsDirectory: "coverage/unit",
       include: [
+        "lib/auth/*.ts",
         "lib/roles.ts",
         "lib/roles-client.ts",
         "lib/streak-service.ts",
@@ -54,6 +62,10 @@ export default defineConfig({
         statements: 90,
         // Authorization is the highest-risk surface in the codebase: every
         // branch of it must be exercised, including the deny-by-default paths.
+        // The permission matrix is the highest-risk code in the repository.
+        "lib/auth/policy.ts": { lines: 100, functions: 100, branches: 100, statements: 100 },
+        "lib/auth/actions.ts": { lines: 100, functions: 100, branches: 100, statements: 100 },
+        "lib/auth/errors.ts": { lines: 100, functions: 100, branches: 100, statements: 100 },
         "lib/roles.ts": { lines: 100, functions: 100, branches: 100, statements: 100 },
         "lib/roles-client.ts": { lines: 100, functions: 100, branches: 100, statements: 100 },
       },


### PR DESCRIPTION
Part 1 of 3 for #42. Rebased onto `dev` after #137 was squash-merged; the diff is now its own three commits.

This PR adds the permission module and retires `TEACHER_ID`. Adopting the module at the 29 call sites is PRs 2 and 3. Plan approved in-session; ADR 0001 is the design authority.

## ⚠️ Required before merge

**Nothing in this repository has ever written `ADMIN` or `FACULTY` to `User.role.`** The Clerk webhook (`app/api/webhooks/clerk/route.ts:80`) creates users at the schema default `STUDENT`, there is no role-management UI (#88), and no seed or migration grants privilege. Unless roles were set by hand in the database, `TEACHER_ID` is currently the only thing making anyone an admin.

So this PR can lock you out. Before merging:

```
npm run role:grant -- --user <your-clerk-id> --role ADMIN
npm run role:list      # confirm the row exists
npm run role:check     # must exit 0
```

The user must have signed in at least once so the webhook created their `User` row — the script refuses to invent one.

Rollback note: redeploying the previous build restores the old code but not the removed variable's effect. **The granted ADMIN row is what makes rollback safe**, which is why it must exist first.

## What this adds

`lib/auth/`, server-only:

| File | Responsibility |
| --- | --- |
| `policy.ts` | `can(principal, action, resource)` — **pure**. No database, clock, or network. The matrix itself. |
| `guards.ts` | The async boundary. Puts the ownership condition *inside* the query that loads the resource (ADR 0001 §4). |
| `principal.ts` | `getPrincipal()` / `requirePrincipal()` — the one derivation point (§1). |
| `actions.ts` | The action vocabulary as a string-literal union. |
| `errors.ts` | `Denied` + `toResponse`. |
| `bootstrap.ts` | `assertAdminExists()`, ready for #103 to mount. |

Plus `scripts/manage-roles.ts` (`role:grant` / `role:list` / `role:check`) and `docs/permission-matrix.md`.

### Why policy is pure and guards are not

Splitting them is what makes exhaustive coverage affordable. `policy.ts` touches nothing, so all **181** matrix cases run in milliseconds and every role × action × ownership combination is asserted rather than sampled. `guards.ts` owns the async half, and its tests assert the emitted `where` clause — a guard that filtered in JavaScript *after* an unfiltered read would pass a return-value test and still be wrong.

Actions map to rules through a total `Record<Action, Rule>`, so adding an action without deciding who may perform it **does not compile**.

### Decisions recorded

- **ADMIN does not override Course ownership.** Preserves what `DELETE /api/courses/[courseId]` enforces today; the wider question is #86's. Asserted in the matrix so changing it is deliberate.
- **Denials carry a reason**: 401 unauthenticated, 403 forbidden, 404 not-found-or-not-owned. The last two are deliberately indistinguishable — separating them turns an endpoint into an oracle for enumerating other people's Courses. Today every handler answers 401, which bounces a signed-in user to sign-in for a permission error. Coordinated with #44.
- **`role:check` is a manual deploy step.** There is no readiness endpoint yet (#103 adds one). CI cannot run it — no database. Saying so rather than implying automation exists.

## Evidence

**302 tests** (up from 92), 100% lines and functions on the covered set. `lib/auth/policy.ts`, `actions.ts`, and `errors.ts` held at 100% branches.

Twelve mutations applied to `policy.ts`:

| Mutation | Result |
| --- | --- |
| `adminOnly` also allows faculty | killed |
| `facultyOwned` drops the ownership term | killed |
| `facultyOwned` drops the role term | killed |
| `facultyGlobal` allows students | killed |
| `FACULTY` implies `ADMIN` | killed |
| Course owner check always true | killed |
| Empty principal id allowed | killed |
| Corrupt role allowed | killed |
| Unknown action allowed | killed |
| Suspended enrollment allowed | killed |
| Reserved actions allowed | killed |
| Null-assignee guard removed | **equivalent** — `can` guarantees a non-empty principal id first, so a non-empty string can never `=== null` |

Checking that survivor surfaced two of my own tests passing for the wrong reason: they used an empty principal id, which short-circuits at the top guard before reaching the logic under test. Both rewritten to exercise what they claim.

Also removed a provably unreachable `if (rule === undefined)` guard in `policy.ts` — `isAction()` narrows to the vocabulary and `RULES` is total, so it was dead code that coverage correctly flagged.

## Commands run

```
npm run validate              # exit 0
npm run test:unit:coverage
npm run build                 # Next.js accepts the server-only boundaries
```

```
Test Files  10 passed (10)
     Tests  302 passed (302)

Statements   : 98.74%  Branches : 96%
Functions    : 100%    Lines    : 100%
```

## Notes

- `server-only` throws outside a React Server Component condition, so it is aliased to the package's own `empty.js` in `vitest.config.mts`. The Next.js build still enforces the real boundary — verified by `npm run build`.
- `docs/permission-matrix.md` needed a `.gitignore` exception: `/docs/*` is ignored with an allowlist for sources of truth. A binding document that exists only on one machine is not binding.
- `lib/roles.ts` survives as a `@deprecated` adapter so the 29 call sites migrate incrementally. It now also refuses a `userId` that is not the session's own, which the old signature accepted. Deleted in PR 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RH1AUJJFKCXc2SuRcML9vg
