### PR TITLE
fix: close the Wave 1 object-level authorization defects (#39, #40, #41)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,16 +3,43 @@
     "next/core-web-vitals",
     "plugin:security/recommended-legacy"
   ],
-  "plugins": ["security"],
+  "plugins": [
+    "security"
+  ],
   "rules": {
     "security/detect-object-injection": "off",
     "no-eval": "error",
     "no-implied-eval": "error",
-    "no-new-func": "error"
+    "no-new-func": "error",
+    "no-restricted-imports": [
+      "error",
+      {
+        "paths": [
+          {
+            "name": "@clerk/nextjs/server",
+            "importNames": [
+              "auth"
+            ],
+            "message": "Derive the principal with getPrincipal/requirePrincipal/requirePagePrincipal from @/lib/auth. ADR 0001 makes that the only place identity enters the application, so a handler cannot invent its own notion of who is calling. Only lib/auth and proxy.ts may call Clerk directly."
+          }
+        ]
+      }
+    ]
   },
   "overrides": [
     {
-      "files": ["scripts/**/*.ts"],
+      "files": [
+        "lib/auth/**/*.ts",
+        "proxy.ts"
+      ],
+      "rules": {
+        "no-restricted-imports": "off"
+      }
+    },
+    {
+      "files": [
+        "scripts/**/*.ts"
+      ],
       "rules": {
         "security/detect-non-literal-fs-filename": "off"
       }

--- a/actions/get-topic.ts
+++ b/actions/get-topic.ts
@@ -1,4 +1,6 @@
 import { db } from "@/lib/db";
+import { logError } from "@/lib/logger";
+import { publishedTopicInCourse } from "@/lib/courses/topic-access";
 import { Attachment, Topic } from "@prisma/client";
 
 interface GetTopicProps {
@@ -32,11 +34,12 @@ export const getTopic = async ({
             }
         });
 
-        const topic = await db.topic.findUnique({
-            where: {
-                id: topicId,
-                isPublished: true,
-            },
+        // Bound to the Course through its Module. Loading by id alone meant a
+        // Topic id from any Course resolved here, and the entitlement check
+        // below looks at the *route's* Course -- so a purchase of one Course
+        // unlocked video and attachments in another.
+        const topic = await db.topic.findFirst({
+            where: publishedTopicInCourse(courseId, topicId),
             include: {
                 module: true,
             }
@@ -176,7 +179,8 @@ export const getTopic = async ({
             purchase,
         };
     } catch (error) {
-        console.log("[GET_TOPIC]", error);
+        // Redacted in production; console.log printed the whole error object.
+        logError("GET_TOPIC", error);
         return {
             topic: null,
             course: null,

--- a/app/(course)/courses/[courseId]/chapters/[chapterId]/page.tsx
+++ b/app/(course)/courses/[courseId]/chapters/[chapterId]/page.tsx
@@ -1,4 +1,4 @@
-import { auth } from "@clerk/nextjs/server";
+import { requirePagePrincipal } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import { File, ChevronLeft, ChevronRight } from "lucide-react";
 import Link from "next/link";
@@ -23,12 +23,7 @@ const ChapterIdPage = async ({
 }) => {
     const { courseId, chapterId } = await params;
 
-    const { userId } = await auth();
-
-    if (!userId) {
-        return redirect("/dashboard");
-    }
-
+    const { userId } = await requirePagePrincipal("/dashboard");
     const {
         topic,
         course,

--- a/app/(course)/courses/[courseId]/layout.tsx
+++ b/app/(course)/courses/[courseId]/layout.tsx
@@ -1,6 +1,6 @@
+import { requirePagePrincipal } from "@/lib/auth";
 import { getProgress } from "@/actions/get-progress";
 import { db } from "@/lib/db";
-import { auth } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
 import { AppShell } from "@/components/shell/app-shell";
 import { CourseSidebar } from "./_components/course-sidebar";
@@ -14,12 +14,7 @@ const CourseLayout = async ({
 }) => {
     const { courseId } = await params;
 
-    const { userId } = await auth();
-
-    if (!userId) {
-        return redirect("/dashboard");
-    }
-
+    const { userId } = await requirePagePrincipal("/dashboard");
     const course = await db.course.findUnique({
         where: {
             id: courseId,

--- a/app/(course)/courses/[courseId]/quiz/[quizId]/page.tsx
+++ b/app/(course)/courses/[courseId]/quiz/[quizId]/page.tsx
@@ -1,4 +1,4 @@
-import { auth } from "@clerk/nextjs/server";
+import { requirePagePrincipal } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import Link from "next/link";
 import { Clock, FileQuestion, Lock, CheckCircle2, ArrowLeft } from "lucide-react";
@@ -16,12 +16,7 @@ const QuizEntryPage = async ({
   params: Promise<{ courseId: string; quizId: string }>;
 }) => {
   const { courseId, quizId } = await params;
-  const { userId } = await auth();
-
-  if (!userId) {
-    return redirect("/sign-in");
-  }
-
+  const { userId } = await requirePagePrincipal("/sign-in");
   const quiz = await db.quiz.findUnique({
     where: {
       id: quizId,

--- a/app/(course)/courses/[courseId]/quiz/[quizId]/results/[attemptId]/page.tsx
+++ b/app/(course)/courses/[courseId]/quiz/[quizId]/results/[attemptId]/page.tsx
@@ -1,4 +1,4 @@
-import { auth } from "@clerk/nextjs/server";
+import { requirePagePrincipal } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import Link from "next/link";
 import { CheckCircle2, XCircle, ArrowLeft, RotateCcw, Clock } from "lucide-react";
@@ -19,12 +19,7 @@ const QuizResultsPage = async ({
   params: Promise<{ courseId: string; quizId: string; attemptId: string }>;
 }) => {
   const { courseId, quizId, attemptId } = await params;
-  const { userId } = await auth();
-
-  if (!userId) {
-    return redirect("/sign-in");
-  }
-
+  const { userId } = await requirePagePrincipal("/sign-in");
   const attempt = await db.quizAttempt.findUnique({
     where: { id: attemptId },
     include: {

--- a/app/(dashboard)/(routes)/community/new/page.tsx
+++ b/app/(dashboard)/(routes)/community/new/page.tsx
@@ -1,4 +1,4 @@
-import { auth } from "@clerk/nextjs/server";
+import { requirePagePrincipal } from "@/lib/auth";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { ArrowLeft } from "lucide-react";
@@ -7,9 +7,7 @@ import { db } from "@/lib/db";
 import { CreatePostForm } from "./_components/create-post-form";
 
 const NewPostPage = async () => {
-  const { userId } = await auth();
-  if (!userId) return redirect("/sign-in");
-
+  const { userId } = await requirePagePrincipal("/sign-in");
   const [categories, enrolledCourses] = await Promise.all([
     db.forumCategory.findMany({ orderBy: { position: "asc" } }),
     db.purchase.findMany({

--- a/app/(dashboard)/(routes)/community/page.tsx
+++ b/app/(dashboard)/(routes)/community/page.tsx
@@ -1,4 +1,4 @@
-import { auth } from "@clerk/nextjs/server";
+import { requirePagePrincipal } from "@/lib/auth";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { Plus } from "lucide-react";
@@ -21,9 +21,7 @@ const CommunityPage = async ({
     page?: string;
   }>;
 }) => {
-  const { userId } = await auth();
-  if (!userId) return redirect("/sign-in");
-
+  const { userId } = await requirePagePrincipal("/sign-in");
   const params = await searchParams;
   const page = parseInt(params.page ?? "1", 10);
 

--- a/app/(dashboard)/(routes)/community/profile/[userId]/page.tsx
+++ b/app/(dashboard)/(routes)/community/profile/[userId]/page.tsx
@@ -1,4 +1,4 @@
-import { auth } from "@clerk/nextjs/server";
+import { requirePagePrincipal } from "@/lib/auth";
 import Link from "next/link";
 import { redirect, notFound } from "next/navigation";
 import { ArrowLeft, Calendar } from "lucide-react";
@@ -12,8 +12,7 @@ const CommunityProfilePage = async ({
 }: {
   params: Promise<{ userId: string }>;
 }) => {
-  const { userId: currentUserId } = await auth();
-  if (!currentUserId) return redirect("/sign-in");
+  const { userId: currentUserId } = await requirePagePrincipal("/sign-in");
 
   const { userId: profileUserId } = await params;
 

--- a/app/(dashboard)/(routes)/courses/[courseId]/page.tsx
+++ b/app/(dashboard)/(routes)/courses/[courseId]/page.tsx
@@ -1,4 +1,4 @@
-import { auth } from "@clerk/nextjs/server";
+import { requirePagePrincipal } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import Link from "next/link";
 import Image from "next/image";
@@ -19,9 +19,7 @@ const CourseDetailPage = async ({
   params: Promise<{ courseId: string }>;
 }) => {
   const { courseId } = await params;
-  const { userId } = await auth();
-  if (!userId) return redirect("/sign-in");
-
+  const { userId } = await requirePagePrincipal("/sign-in");
   const course = await getCourseDetail(userId, courseId);
   if (!course) return redirect("/courses");
 

--- a/app/(dashboard)/(routes)/courses/page.tsx
+++ b/app/(dashboard)/(routes)/courses/page.tsx
@@ -1,4 +1,4 @@
-import { auth } from "@clerk/nextjs/server";
+import { requirePagePrincipal } from "@/lib/auth";
 import { redirect } from "next/navigation";
 
 import { getEnrolledCourses } from "@/actions/get-enrolled-courses";
@@ -13,9 +13,7 @@ const CoursesPage = async ({
 }: {
   searchParams: Promise<{ search?: string; status?: string; view?: string }>;
 }) => {
-  const { userId } = await auth();
-  if (!userId) return redirect("/sign-in");
-
+  const { userId } = await requirePagePrincipal("/sign-in");
   const params = await searchParams;
   const filter = (params.status as "all" | "in_progress" | "completed" | "not_started") || "all";
   const search = params.search || undefined;

--- a/app/(dashboard)/(routes)/dashboard/page.tsx
+++ b/app/(dashboard)/(routes)/dashboard/page.tsx
@@ -1,4 +1,4 @@
-import { auth } from "@clerk/nextjs/server";
+import { requirePagePrincipal } from "@/lib/auth";
 import { redirect } from "next/navigation";
 
 import { getEnrolledCourses } from "@/actions/get-enrolled-courses";
@@ -25,9 +25,7 @@ export default async function Dashboard({
 }: {
   searchParams: Promise<{ courseId?: string; period?: string }>;
 }) {
-  const { userId } = await auth();
-  if (!userId) return redirect("/sign-in");
-
+  const { userId } = await requirePagePrincipal("/sign-in");
   const params = await searchParams;
   const selectedCourseId = params.courseId;
   const period = (params.period === "monthly" ? "monthly" : "weekly") as

--- a/app/(dashboard)/(routes)/grades/[courseId]/page.tsx
+++ b/app/(dashboard)/(routes)/grades/[courseId]/page.tsx
@@ -1,4 +1,4 @@
-import { auth } from "@clerk/nextjs/server";
+import { requirePagePrincipal } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import Link from "next/link";
 import { ArrowLeft, CheckCircle2, Circle, Clock } from "lucide-react";
@@ -27,12 +27,7 @@ const GradesDetailPage = async ({
   params: Promise<{ courseId: string }>;
 }) => {
   const { courseId } = await params;
-  const { userId } = await auth();
-
-  if (!userId) {
-    return redirect("/sign-in");
-  }
-
+  const { userId } = await requirePagePrincipal("/sign-in");
   const [detail, certificate] = await Promise.all([
     getGradesDetail(userId, courseId),
     getCertificate(userId, courseId),

--- a/app/(dashboard)/(routes)/grades/page.tsx
+++ b/app/(dashboard)/(routes)/grades/page.tsx
@@ -1,4 +1,4 @@
-import { auth } from "@clerk/nextjs/server";
+import { requirePagePrincipal } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import Link from "next/link";
 import { ArrowUp, ArrowDown, GraduationCap } from "lucide-react";
@@ -18,12 +18,7 @@ import {
 import { cn } from "@/lib/utils";
 
 const GradesPage = async () => {
-  const { userId } = await auth();
-
-  if (!userId) {
-    return redirect("/sign-in");
-  }
-
+  const { userId } = await requirePagePrincipal("/sign-in");
   const grades = await getGradesOverview(userId);
 
   // Calculate overall average

--- a/app/(dashboard)/(routes)/journal/[entryId]/page.tsx
+++ b/app/(dashboard)/(routes)/journal/[entryId]/page.tsx
@@ -1,4 +1,4 @@
-import { auth } from "@clerk/nextjs/server";
+import { requirePagePrincipal } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import { notFound } from "next/navigation";
 
@@ -10,9 +10,7 @@ export default async function EditJournalEntryPage({
 }: {
   params: Promise<{ entryId: string }>;
 }) {
-  const { userId } = await auth();
-  if (!userId) return redirect("/sign-in");
-
+  const { userId } = await requirePagePrincipal("/sign-in");
   const { entryId } = await params;
 
   const entry = await db.journalEntry.findUnique({

--- a/app/(dashboard)/(routes)/journal/new/page.tsx
+++ b/app/(dashboard)/(routes)/journal/new/page.tsx
@@ -1,4 +1,4 @@
-import { auth } from "@clerk/nextjs/server";
+import { requirePagePrincipal } from "@/lib/auth";
 import { redirect } from "next/navigation";
 
 import { db } from "@/lib/db";
@@ -13,9 +13,7 @@ export default async function NewJournalEntryPage({
     prompt?: string;
   }>;
 }) {
-  const { userId } = await auth();
-  if (!userId) return redirect("/sign-in");
-
+  const { userId } = await requirePagePrincipal("/sign-in");
   const params = await searchParams;
 
   // Get user's enrolled courses for the course selector

--- a/app/(dashboard)/(routes)/journal/page.tsx
+++ b/app/(dashboard)/(routes)/journal/page.tsx
@@ -1,4 +1,4 @@
-import { auth } from "@clerk/nextjs/server";
+import { requirePagePrincipal } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import Link from "next/link";
 
@@ -17,9 +17,7 @@ export default async function JournalPage({
     search?: string;
   }>;
 }) {
-  const { userId } = await auth();
-  if (!userId) return redirect("/sign-in");
-
+  const { userId } = await requirePagePrincipal("/sign-in");
   const params = await searchParams;
 
   const entries = await getJournalEntries({

--- a/app/(dashboard)/(routes)/learning-path/page.tsx
+++ b/app/(dashboard)/(routes)/learning-path/page.tsx
@@ -1,4 +1,4 @@
-import { auth } from "@clerk/nextjs/server";
+import { requirePagePrincipal } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import { Map } from "lucide-react";
 
@@ -9,12 +9,7 @@ import { LearningPathMap } from "./_components/learning-path-map";
 import { PageContainer } from "@/components/shell/page-container";
 
 const LearningPathPage = async () => {
-  const { userId } = await auth();
-
-  if (!userId) {
-    return redirect("/sign-in");
-  }
-
+  const { userId } = await requirePagePrincipal("/sign-in");
   const courses = await getLearningPath(userId);
 
   const completedCount = courses.filter((c) => c.status === "COMPLETED").length;

--- a/app/(dashboard)/(routes)/search/page.tsx
+++ b/app/(dashboard)/(routes)/search/page.tsx
@@ -1,4 +1,4 @@
-import { auth } from "@clerk/nextjs/server";
+import { requirePagePrincipal } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import { Suspense } from "react";
 
@@ -21,11 +21,7 @@ interface SearchPageProps {
 const SearchPage = async ({
     searchParams
 }: SearchPageProps) => {
-    const { userId } = await auth();
-
-    if (!userId) {
-        return redirect("/dashboard");
-    }
+    const { userId } = await requirePagePrincipal("/dashboard");
     const categories = await db.category.findMany({
         orderBy: {
             name: "asc",

--- a/app/(dashboard)/(routes)/settings/page.tsx
+++ b/app/(dashboard)/(routes)/settings/page.tsx
@@ -1,4 +1,4 @@
-import { auth } from "@clerk/nextjs/server";
+import { requirePagePrincipal } from "@/lib/auth";
 import { redirect } from "next/navigation";
 
 import { getUserSettings } from "@/actions/get-user-settings";
@@ -7,12 +7,7 @@ import { SettingsForm } from "./_components/settings-form";
 import { PageContainer } from "@/components/shell/page-container";
 
 const SettingsPage = async () => {
-  const { userId } = await auth();
-
-  if (!userId) {
-    return redirect("/sign-in");
-  }
-
+  const { userId } = await requirePagePrincipal("/sign-in");
   const settings = await getUserSettings(userId);
 
   return (

--- a/app/(dashboard)/(routes)/teacher/analytics/page.tsx
+++ b/app/(dashboard)/(routes)/teacher/analytics/page.tsx
@@ -1,4 +1,4 @@
-import { auth } from "@clerk/nextjs/server";
+import { requirePagePrincipal } from "@/lib/auth";
 import { redirect } from "next/navigation";
 
 import { getAnalytics } from "@/actions/get-analytics";
@@ -7,12 +7,7 @@ import { Chart } from "./_components/chart";
 import { PageContainer } from "@/components/shell/page-container";
 
 const AnalyticsPage = async () => {
-    const { userId } = await auth();
-
-    if (!userId) {
-        return redirect("/dashboard");
-    }
-
+    const { userId } = await requirePagePrincipal("/dashboard");
     const {
         data,
         totalRevenue,

--- a/app/(dashboard)/(routes)/teacher/courses/[courseId]/chapters/[chapterId]/page.tsx
+++ b/app/(dashboard)/(routes)/teacher/courses/[courseId]/chapters/[chapterId]/page.tsx
@@ -1,4 +1,4 @@
-import { auth } from "@clerk/nextjs/server";
+import { requirePagePrincipal } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import Link from "next/link";
 import { ArrowLeft, Eye, LayoutDashboard, Video } from "lucide-react";
@@ -21,12 +21,7 @@ const ChapterIdPAge = async ({
     const { courseId, chapterId } = await params;
 
 
-    const { userId } = await auth();
-
-    if (!userId) {
-        return redirect("/dashboard");
-    }
-
+    const { userId } = await requirePagePrincipal("/dashboard");
     const chapter = await db.topic.findUnique({
         where: {
             id: chapterId,

--- a/app/(dashboard)/(routes)/teacher/courses/[courseId]/page.tsx
+++ b/app/(dashboard)/(routes)/teacher/courses/[courseId]/page.tsx
@@ -1,4 +1,4 @@
-import { auth } from "@clerk/nextjs/server";
+import { requirePagePrincipal } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import { CircleDollarSign, File, LayoutDashboard, ListChecks } from "lucide-react";
 
@@ -21,12 +21,7 @@ const CourseIdPage = async ({
     params: Promise<{courseId: string}>
 }) => {
     const { courseId } = await params;
-    const { userId } = await auth();
-
-    if (!userId) {
-        return redirect("/dashboard");
-    }
-
+    const { userId } = await requirePagePrincipal("/dashboard");
     const course = await db.course.findUnique({
         where: {
             id: courseId,

--- a/app/(dashboard)/(routes)/teacher/courses/page.tsx
+++ b/app/(dashboard)/(routes)/teacher/courses/page.tsx
@@ -1,4 +1,4 @@
-import { auth } from "@clerk/nextjs/server";
+import { requirePagePrincipal } from "@/lib/auth";
 import { redirect } from "next/navigation";
 
 import { db } from "@/lib/db";
@@ -9,12 +9,7 @@ import { PageContainer } from "@/components/shell/page-container";
 
 
 const CoursesPage = async () => {
-    const { userId } = await auth();
-
-    if (!userId) {
-        return redirect("/dashboard");
-    }
-
+    const { userId } = await requirePagePrincipal("/dashboard");
     const courses = await db.course.findMany({
         where: {
             userId,

--- a/app/api/community/comments/[commentId]/like/route.ts
+++ b/app/api/community/comments/[commentId]/like/route.ts
@@ -1,7 +1,7 @@
-import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 
 import { db } from "@/lib/db";
+import { requirePrincipal, toResponse } from "@/lib/auth";
 import { logError } from "@/lib/logger";
 
 export async function POST(
@@ -9,10 +9,7 @@ export async function POST(
   { params }: { params: Promise<{ commentId: string }> }
 ) {
   try {
-    const { userId } = await auth();
-    if (!userId) {
-      return new NextResponse("Unauthorized", { status: 401 });
-    }
+    const { userId } = await requirePrincipal();
 
     const { commentId } = await params;
 
@@ -37,6 +34,9 @@ export async function POST(
       count,
     });
   } catch (error) {
+    const denied = toResponse(error);
+    if (denied) return denied;
+
     logError("COMMUNITY_COMMENT_LIKE", error);
     return new NextResponse("Internal Error", { status: 500 });
   }

--- a/app/api/community/posts/[postId]/comments/route.ts
+++ b/app/api/community/posts/[postId]/comments/route.ts
@@ -1,7 +1,7 @@
-import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 
 import { db } from "@/lib/db";
+import { requirePrincipal, toResponse } from "@/lib/auth";
 import { evaluateBadges } from "@/lib/badge-service";
 import { logError } from "@/lib/logger";
 
@@ -10,10 +10,7 @@ export async function POST(
   { params }: { params: Promise<{ postId: string }> }
 ) {
   try {
-    const { userId } = await auth();
-    if (!userId) {
-      return new NextResponse("Unauthorized", { status: 401 });
-    }
+    const { userId } = await requirePrincipal();
 
     const { postId } = await params;
     const { content, parentId } = await req.json();
@@ -89,6 +86,9 @@ export async function POST(
       })),
     });
   } catch (error) {
+    const denied = toResponse(error);
+    if (denied) return denied;
+
     logError("COMMUNITY_COMMENT_POST", error);
     return new NextResponse("Internal Error", { status: 500 });
   }

--- a/app/api/community/posts/[postId]/like/route.ts
+++ b/app/api/community/posts/[postId]/like/route.ts
@@ -1,7 +1,7 @@
-import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 
 import { db } from "@/lib/db";
+import { requirePrincipal, toResponse } from "@/lib/auth";
 import { logError } from "@/lib/logger";
 
 export async function POST(
@@ -9,10 +9,7 @@ export async function POST(
   { params }: { params: Promise<{ postId: string }> }
 ) {
   try {
-    const { userId } = await auth();
-    if (!userId) {
-      return new NextResponse("Unauthorized", { status: 401 });
-    }
+    const { userId } = await requirePrincipal();
 
     const { postId } = await params;
 
@@ -37,6 +34,9 @@ export async function POST(
       count,
     });
   } catch (error) {
+    const denied = toResponse(error);
+    if (denied) return denied;
+
     logError("COMMUNITY_POST_LIKE", error);
     return new NextResponse("Internal Error", { status: 500 });
   }

--- a/app/api/community/posts/route.ts
+++ b/app/api/community/posts/route.ts
@@ -1,16 +1,13 @@
-import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 
 import { db } from "@/lib/db";
+import { requirePrincipal, toResponse } from "@/lib/auth";
 import { evaluateBadges } from "@/lib/badge-service";
 import { logError } from "@/lib/logger";
 
 export async function POST(req: Request) {
   try {
-    const { userId } = await auth();
-    if (!userId) {
-      return new NextResponse("Unauthorized", { status: 401 });
-    }
+    const { userId } = await requirePrincipal();
 
     const { title, content, categoryId, courseId } = await req.json();
 
@@ -43,6 +40,9 @@ export async function POST(req: Request) {
       })),
     });
   } catch (error) {
+    const denied = toResponse(error);
+    if (denied) return denied;
+
     logError("COMMUNITY_POSTS_POST", error);
     return new NextResponse("Internal Error", { status: 500 });
   }

--- a/app/api/courses/[courseId]/attachments/[attachmentId]/route.ts
+++ b/app/api/courses/[courseId]/attachments/[attachmentId]/route.ts
@@ -1,5 +1,5 @@
 import { db } from "@/lib/db";
-import { auth } from "@clerk/nextjs/server";
+import { authorizeCourse, requirePrincipal, toResponse } from "@/lib/auth";
 import { NextResponse } from "next/server";
 import { logError } from "@/lib/logger";
 
@@ -10,22 +10,9 @@ export async function DELETE(
         const routeParams = await params;
 
     try {
-        const { userId } = await auth();
-
-        if (!userId) {
-            return new NextResponse("Unauthorized", { status: 401 });
-        }
-
-        const courseOwner = await db.course.findUnique({
-            where: {
-                id: routeParams.courseId,
-                userId: userId,
-            }
-        });
-
-        if (!courseOwner) {
-            return new NextResponse("Unauthorized", { status: 401 });
-        }
+        const principal = await requirePrincipal();
+        await authorizeCourse(principal, "attachment:delete", routeParams.courseId);
+        const userId = principal.userId;
 
         const attachment = await db.attachment.delete({
             where: {
@@ -36,6 +23,9 @@ export async function DELETE(
 
         return NextResponse.json(attachment);
     } catch (error) {
+        const denied = toResponse(error);
+        if (denied) return denied;
+
         logError("ATTACHMENT_ID", error);
         return new NextResponse("Internal Error", { status: 500 });
     }

--- a/app/api/courses/[courseId]/attachments/route.ts
+++ b/app/api/courses/[courseId]/attachments/route.ts
@@ -1,7 +1,7 @@
-import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server"
 
 import { db } from "@/lib/db";
+import { authorizeCourse, requirePrincipal, toResponse } from "@/lib/auth";
 import { logError } from "@/lib/logger";
 
 
@@ -12,23 +12,10 @@ export async function POST(
         const routeParams = await params;
 
     try {
-        const { userId } = await auth();
+        const principal = await requirePrincipal();
+        await authorizeCourse(principal, "attachment:create", routeParams.courseId);
+        const userId = principal.userId;
         const { url } = await req.json();
-
-        if (!userId) {
-            return new NextResponse("Unauthorized", { status: 401 });
-        }
-
-        const courseOwner = await db.course.findUnique({
-            where: {
-                id: routeParams.courseId,
-                userId: userId,
-            }
-        });
-
-        if (!courseOwner) {
-            return new NextResponse("Unauthorized", { status: 401 });
-        }
 
         const attachment = await db.attachment.create({
             data: {
@@ -41,6 +28,9 @@ export async function POST(
         return NextResponse.json(attachment);
 
     } catch (error) {
+        const denied = toResponse(error);
+        if (denied) return denied;
+
         logError("COURSE_ID_ATTACHMENTS", error);
         return new NextResponse("Internal Error", { status: 500 });
     }

--- a/app/api/courses/[courseId]/case-studies/[caseStudyId]/attempt/route.ts
+++ b/app/api/courses/[courseId]/case-studies/[caseStudyId]/attempt/route.ts
@@ -1,7 +1,7 @@
-import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 
 import { db } from "@/lib/db";
+import { requirePrincipal, toResponse } from "@/lib/auth";
 import { logError } from "@/lib/logger";
 
 export async function POST(
@@ -9,10 +9,7 @@ export async function POST(
   { params }: { params: Promise<{ caseStudyId: string }> }
 ) {
   try {
-    const { userId } = await auth();
-    if (!userId) {
-      return new NextResponse("Unauthorized", { status: 401 });
-    }
+    const { userId } = await requirePrincipal();
 
     const { caseStudyId } = await params;
     const { choices, completed } = await req.json();
@@ -28,6 +25,9 @@ export async function POST(
 
     return NextResponse.json(attempt);
   } catch (error) {
+    const denied = toResponse(error);
+    if (denied) return denied;
+
     logError("CASE_STUDY_ATTEMPT", error);
     return new NextResponse("Internal Error", { status: 500 });
   }

--- a/app/api/courses/[courseId]/certificate/route.ts
+++ b/app/api/courses/[courseId]/certificate/route.ts
@@ -1,7 +1,7 @@
-import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 
 import { db } from "@/lib/db";
+import { requirePrincipal, toResponse } from "@/lib/auth";
 import { generateCertificate } from "@/lib/certificate-service";
 import { logError } from "@/lib/logger";
 
@@ -12,10 +12,7 @@ export async function POST(
   { params }: { params: Promise<{ courseId: string }> }
 ) {
   try {
-    const { userId } = await auth();
-    if (!userId) {
-      return new NextResponse("Unauthorized", { status: 401 });
-    }
+    const { userId } = await requirePrincipal();
 
     const { courseId } = await params;
 
@@ -42,6 +39,9 @@ export async function POST(
 
     return NextResponse.json(result);
   } catch (error) {
+    const denied = toResponse(error);
+    if (denied) return denied;
+
     logError("CERTIFICATE_POST", error);
     return new NextResponse("Internal Error", { status: 500 });
   }
@@ -52,10 +52,7 @@ export async function GET(
   { params }: { params: Promise<{ courseId: string }> }
 ) {
   try {
-    const { userId } = await auth();
-    if (!userId) {
-      return new NextResponse("Unauthorized", { status: 401 });
-    }
+    const { userId } = await requirePrincipal();
 
     const { courseId } = await params;
 
@@ -73,6 +70,9 @@ export async function GET(
       issuedAt: certificate.issuedAt,
     });
   } catch (error) {
+    const denied = toResponse(error);
+    if (denied) return denied;
+
     logError("CERTIFICATE_GET", error);
     return new NextResponse("Internal Error", { status: 500 });
   }

--- a/app/api/courses/[courseId]/chapters/[chapterId]/progress/route.ts
+++ b/app/api/courses/[courseId]/chapters/[chapterId]/progress/route.ts
@@ -1,12 +1,24 @@
 import { NextResponse } from "next/server";
 
+import { z } from "zod";
+
 import { db } from "@/lib/db";
 import { requirePrincipal, toResponse } from "@/lib/auth";
-import { topicBelongsToCourse } from "@/lib/courses/topic-access";
+import { findPublishedTopicInCourse } from "@/lib/courses/topic-access";
+import {
+    isCourseComplete as courseIsComplete,
+    isModuleComplete as moduleIsComplete,
+} from "@/lib/courses/completion";
 import { evaluateBadges, type BadgeEvent } from "@/lib/badge-service";
 import { updateStreak } from "@/lib/streak-service";
 import { generateCertificate } from "@/lib/certificate-service";
 import { logError } from "@/lib/logger";
+
+const progressSchema = z.object({
+    // Runtime-validated: the value drives Enrollment status and certificate
+    // issuance, and JSON will happily deliver a string, a number, or an object.
+    isCompleted: z.boolean(),
+});
 
 export async function PUT(
     req: Request,
@@ -17,16 +29,39 @@ export async function PUT(
     try {
         const { userId } = await requirePrincipal();
 
-        // The Topic must actually be in this Course. Without this, a progress
-        // write could be aimed at any Topic in the product by id, and the
-        // completion cascade below -- badges, streaks, Enrollment status, and
-        // certificate issuance -- would run for a Course the learner is not on.
-        // Entitlement itself (must the learner be enrolled?) is #40.
-        if (!(await topicBelongsToCourse(routeParams.courseId, routeParams.chapterId))) {
+        // Published, and in this Course. Without the binding a progress write
+        // could be aimed at any Topic in the product by id, and the cascade
+        // below -- badges, streaks, Enrollment status, certificate issuance --
+        // would run for a Course the learner is not on.
+        const topic = await findPublishedTopicInCourse(
+            routeParams.courseId,
+            routeParams.chapterId
+        );
+
+        if (!topic) {
             return new NextResponse("Not Found", { status: 404 });
         }
 
-        const { isCompleted } = await req.json();
+        // Entitlement. A free-preview Topic is progressable without a purchase;
+        // anything else requires one. Enrollment becomes the canonical record
+        // in #48, at which point this reads from there instead.
+        if (!topic.isFree) {
+            const purchase = await db.purchase.findUnique({
+                where: {
+                    userId_courseId: { userId, courseId: routeParams.courseId },
+                },
+            });
+
+            if (!purchase) {
+                return new NextResponse("Not Found", { status: 404 });
+            }
+        }
+
+        const parsed = progressSchema.safeParse(await req.json());
+        if (!parsed.success) {
+            return new NextResponse("Invalid data", { status: 400 });
+        }
+        const { isCompleted } = parsed.data;
 
         const userProgress = await db.userProgress.upsert({
             where: {
@@ -50,34 +85,35 @@ export async function PUT(
         let moduleName = "";
 
         if (isCompleted) {
-            const topic = await db.topic.findUnique({
-                where: { id: routeParams.chapterId },
+            const owningModule = await db.module.findUnique({
+                where: { id: topic.moduleId },
                 select: {
-                    moduleId: true,
-                    module: {
+                    title: true,
+                    topics: {
+                        where: { isPublished: true },
                         select: {
-                            title: true,
-                            topics: {
-                                where: { isPublished: true },
-                                select: {
-                                    id: true,
-                                    userProgress: {
-                                        where: { userId },
-                                        select: { isCompleted: true },
-                                    },
-                                },
+                            id: true,
+                            userProgress: {
+                                where: { userId },
+                                select: { isCompleted: true },
                             },
                         },
                     },
                 },
             });
 
-            if (topic?.module) {
-                moduleName = topic.module.title;
-                isModuleComplete = topic.module.topics.every((t) =>
-                    t.id === routeParams.chapterId
-                        ? true // just completed this one
-                        : t.userProgress.some((p) => p.isCompleted)
+            if (owningModule) {
+                moduleName = owningModule.title;
+                // A Module with no published Topics is not complete. `[].every()`
+                // is true, so the previous check treated emptiness as success.
+                isModuleComplete = moduleIsComplete(
+                    {
+                        topics: owningModule.topics.map((t) => ({
+                            id: t.id,
+                            completed: t.userProgress.some((p) => p.isCompleted),
+                        })),
+                    },
+                    routeParams.chapterId
                 );
             }
 
@@ -89,7 +125,7 @@ export async function PUT(
                 { type: "streak_updated", currentStreak },
             ];
 
-            if (isModuleComplete && topic?.moduleId) {
+            if (isModuleComplete) {
                 badgeEvents.push({ type: "module_completed", moduleId: topic.moduleId });
             }
 
@@ -111,12 +147,17 @@ export async function PUT(
                     },
                 });
 
-                const isCourseComplete = allModules.every((mod) =>
-                    mod.topics.every((t) =>
-                        t.id === routeParams.chapterId
-                            ? true
-                            : t.userProgress.some((p) => p.isCompleted)
-                    )
+                // Non-vacuous: a Course with no published Topics at all cannot
+                // be complete. Otherwise a draft Course issued a certificate for
+                // finishing nothing.
+                const isCourseComplete = courseIsComplete(
+                    allModules.map((mod) => ({
+                        topics: mod.topics.map((t) => ({
+                            id: t.id,
+                            completed: t.userProgress.some((p) => p.isCompleted),
+                        })),
+                    })),
+                    routeParams.chapterId
                 );
 
                 if (isCourseComplete) {

--- a/app/api/courses/[courseId]/chapters/[chapterId]/progress/route.ts
+++ b/app/api/courses/[courseId]/chapters/[chapterId]/progress/route.ts
@@ -1,7 +1,8 @@
-import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 
 import { db } from "@/lib/db";
+import { requirePrincipal, toResponse } from "@/lib/auth";
+import { topicBelongsToCourse } from "@/lib/courses/topic-access";
 import { evaluateBadges, type BadgeEvent } from "@/lib/badge-service";
 import { updateStreak } from "@/lib/streak-service";
 import { generateCertificate } from "@/lib/certificate-service";
@@ -14,12 +15,18 @@ export async function PUT(
         const routeParams = await params;
 
     try {
-        const { userId } = await auth();
-        const { isCompleted } = await req.json();
+        const { userId } = await requirePrincipal();
 
-        if (!userId) {
-            return new NextResponse("Unauthorized", { status: 401 });
+        // The Topic must actually be in this Course. Without this, a progress
+        // write could be aimed at any Topic in the product by id, and the
+        // completion cascade below -- badges, streaks, Enrollment status, and
+        // certificate issuance -- would run for a Course the learner is not on.
+        // Entitlement itself (must the learner be enrolled?) is #40.
+        if (!(await topicBelongsToCourse(routeParams.courseId, routeParams.chapterId))) {
+            return new NextResponse("Not Found", { status: 404 });
         }
+
+        const { isCompleted } = await req.json();
 
         const userProgress = await db.userProgress.upsert({
             where: {
@@ -158,6 +165,9 @@ export async function PUT(
         });
 
     } catch (error) {
+        const denied = toResponse(error);
+        if (denied) return denied;
+
         logError("CHAPTER_ID_PROGRESS", error);
         return new NextResponse("Internal Error", { status: 500 });
     }

--- a/app/api/courses/[courseId]/chapters/[chapterId]/publish/route.ts
+++ b/app/api/courses/[courseId]/chapters/[chapterId]/publish/route.ts
@@ -1,5 +1,5 @@
 import { db } from "@/lib/db";
-import { auth } from "@clerk/nextjs/server";
+import { authorizeTopicInCourse, requirePrincipal, toResponse } from "@/lib/auth";
 import { NextResponse } from "next/server";
 import { logError } from "@/lib/logger";
 
@@ -10,28 +10,14 @@ export async function PATCH(
         const routeParams = await params;
 
     try {
-        const { userId } = await auth();
+        const principal = await requirePrincipal();
 
-        if (!userId) {
-            return new NextResponse("Unauthorized", { status: 401 });
-        }
-
-        const ownCourse = await db.course.findUnique({
-            where: {
-                id: routeParams.courseId,
-                userId,
-            }
-        });
-
-        if (!ownCourse) {
-            return new NextResponse("Unauthorized", { status: 401 });
-        }
-
-        const topic = await db.topic.findUnique({
-            where: {
-                id: routeParams.chapterId,
-            }
-        });
+        const topic = await authorizeTopicInCourse(
+            principal,
+            "topic:update",
+            routeParams.courseId,
+            routeParams.chapterId
+        );
 
         const muxData = await db.muxData.findUnique({
             where: {
@@ -54,6 +40,9 @@ export async function PATCH(
 
         return NextResponse.json(publishedTopic);
     } catch (error) {
+        const denied = toResponse(error);
+        if (denied) return denied;
+
         logError("CHAPTER_PUBLISH", error);
         return new NextResponse("Internal Error", { status: 500 });
     }

--- a/app/api/courses/[courseId]/chapters/[chapterId]/route.ts
+++ b/app/api/courses/[courseId]/chapters/[chapterId]/route.ts
@@ -1,8 +1,8 @@
 import { Mux } from "@mux/mux-node";
-import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 
 import { db } from "@/lib/db";
+import { authorizeTopicInCourse, requirePrincipal, toResponse } from "@/lib/auth";
 import { topicUpdateSchema } from "@/lib/validations/topic";
 import { logError } from "@/lib/logger";
 
@@ -20,32 +20,17 @@ export async function DELETE(
         const routeParams = await params;
 
     try {
-        const { userId } = await auth();
+        const principal = await requirePrincipal();
 
-        if (!userId) {
-            return new NextResponse("Unauthorized", { status: 401 });
-        }
-
-        const ownCourse = await db.course.findUnique({
-            where: {
-                id: routeParams.courseId,
-                userId,
-            }
-        });
-
-        if (!ownCourse) {
-            return new NextResponse("Unauthorized", { status: 401 });
-        }
-
-        const topic = await db.topic.findUnique({
-            where:{
-                id: routeParams.chapterId,
-            }
-        });
-
-        if (!topic) {
-            return new NextResponse("Topic Not Found", { status: 404 });
-        }
+        // Asserts Course ownership AND that the Topic is in that Course. The
+        // two used to be separate, so owning any Course was enough to reach a
+        // Topic in any other.
+        const topic = await authorizeTopicInCourse(
+            principal,
+            "topic:delete",
+            routeParams.courseId,
+            routeParams.chapterId
+        );
 
         if (topic.videoUrl) {
             const existingMuxData = await db.muxData.findFirst({
@@ -90,6 +75,9 @@ export async function DELETE(
 
         return NextResponse.json(deletedTopic);
     } catch (error) {
+        const denied = toResponse(error);
+        if (denied) return denied;
+
         logError("CHAPTER_ID_DELETE", error);
 
         return new NextResponse("Internal Error", { status: 500 });
@@ -103,28 +91,22 @@ export async function PATCH(
         const routeParams = await params;
 
     try {
-        const { userId } = await auth();
+        const principal = await requirePrincipal();
+
+        // Course ownership and Topic membership together. Previously the Topic
+        // was updated by id alone, so an owner of any Course could edit a Topic
+        // belonging to another.
+        await authorizeTopicInCourse(
+            principal,
+            "topic:update",
+            routeParams.courseId,
+            routeParams.chapterId
+        );
 
         const body = await req.json();
-
-        if (!userId) {
-            return new NextResponse("Unauthorized", { status: 401 });
-        }
-
         const parsed = topicUpdateSchema.safeParse(body);
         if (!parsed.success) {
             return new NextResponse("Invalid data", { status: 400 });
-        }
-
-        const ownCourse = await db.course.findUnique({
-            where: {
-                id: routeParams.courseId,
-                userId
-            }
-        });
-
-        if (!ownCourse) {
-            return new NextResponse("Unauthorized", { status: 401 });
         }
 
         const updatedTopic = await db.topic.update({
@@ -168,6 +150,9 @@ export async function PATCH(
         return NextResponse.json(updatedTopic);
 
     } catch (error) {
+        const denied = toResponse(error);
+        if (denied) return denied;
+
         logError("COURSES_CHAPTER_ID", error);
 
         return new NextResponse("Internal Error", { status: 500 });

--- a/app/api/courses/[courseId]/chapters/[chapterId]/unpublish/route.ts
+++ b/app/api/courses/[courseId]/chapters/[chapterId]/unpublish/route.ts
@@ -1,5 +1,5 @@
 import { db } from "@/lib/db";
-import { auth } from "@clerk/nextjs/server";
+import { authorizeTopicInCourse, requirePrincipal, toResponse } from "@/lib/auth";
 import { NextResponse } from "next/server";
 import { logError } from "@/lib/logger";
 
@@ -10,22 +10,9 @@ export async function PATCH(
         const routeParams = await params;
 
     try {
-        const { userId } = await auth();
-
-        if (!userId) {
-            return new NextResponse("Unauthorized", { status: 401 });
-        }
-
-        const ownCourse = await db.course.findUnique({
-            where: {
-                id: routeParams.courseId,
-                userId,
-            }
-        });
-
-        if (!ownCourse) {
-            return new NextResponse("Unauthorized", { status: 401 });
-        }
+        const principal = await requirePrincipal();
+        await authorizeTopicInCourse(principal, "topic:update", routeParams.courseId, routeParams.chapterId);
+        const userId = principal.userId;
 
         const unpublishedTopic = await db.topic.update({
             where: {
@@ -56,6 +43,9 @@ export async function PATCH(
 
         return NextResponse.json(unpublishedTopic);
     } catch (error) {
+        const denied = toResponse(error);
+        if (denied) return denied;
+
         logError("CHAPTER_UNPUBLISH", error);
         return new NextResponse("Internal Error", { status: 500 });
     }

--- a/app/api/courses/[courseId]/chapters/reorder/route.ts
+++ b/app/api/courses/[courseId]/chapters/reorder/route.ts
@@ -1,5 +1,5 @@
 import { db } from "@/lib/db";
-import { auth } from "@clerk/nextjs/server";
+import { authorizeCourse, requirePrincipal, toResponse } from "@/lib/auth";
 import { NextResponse } from "next/server";
 import { logError } from "@/lib/logger";
 
@@ -10,24 +10,11 @@ export async function PUT(
         const routeParams = await params;
 
     try {
-        const { userId } = await auth();
-
-        if (!userId) {
-            return new NextResponse("Unauthorized", { status: 401 });
-        }
+        const principal = await requirePrincipal();
+        await authorizeCourse(principal, "topic:reorder", routeParams.courseId);
+        const userId = principal.userId;
 
         const { list } = await req.json();
-
-        const ownCourse = await db.course.findUnique({
-            where: {
-                id: routeParams.courseId,
-                userId: userId
-            }
-        });
-
-        if (!ownCourse) {
-            return new NextResponse("Unauthorized", { status: 401 });
-        }
 
         for (let item of list) {
             await db.topic.update({
@@ -39,6 +26,9 @@ export async function PUT(
         return new NextResponse("Success", { status: 200 });
 
     } catch (error) {
+        const denied = toResponse(error);
+        if (denied) return denied;
+
         logError("REORDER", error);
         return new NextResponse("Internal Error", { status: 500 });
     }

--- a/app/api/courses/[courseId]/chapters/route.ts
+++ b/app/api/courses/[courseId]/chapters/route.ts
@@ -1,8 +1,9 @@
-import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 
 import { db } from "@/lib/db";
+import { authorizeCourse, requirePrincipal, toResponse } from "@/lib/auth";
 import { logError } from "@/lib/logger";
+
 export async function POST(
     req: Request,
     { params }: { params: Promise<{ courseId: string }> }
@@ -10,23 +11,10 @@ export async function POST(
         const routeParams = await params;
 
     try {
-        const { userId } = await auth();
+        const principal = await requirePrincipal();
+        await authorizeCourse(principal, "topic:create", routeParams.courseId);
+
         const { title } = await req.json();
-
-        if (!userId) {
-            return new NextResponse("Unauthorized", { status: 401 });
-        }
-
-        const courseOwner = await db.course.findUnique({
-            where: {
-                id: routeParams.courseId,
-                userId: userId,
-            }
-        });
-
-        if (!courseOwner) {
-            return new NextResponse("Unauthorized", { status: 401 });
-        }
 
         // Find or create a default module for the course
         let defaultModule = await db.module.findFirst({
@@ -65,6 +53,9 @@ export async function POST(
         return NextResponse.json(topic);
 
     } catch (error) {
+        const denied = toResponse(error);
+        if (denied) return denied;
+
         logError("CHAPTERS", error);
         return new NextResponse("Internal Server Error", { status: 500 })
     }

--- a/app/api/courses/[courseId]/checkout/route.ts
+++ b/app/api/courses/[courseId]/checkout/route.ts
@@ -1,4 +1,5 @@
 import { db } from "@/lib/db";
+import { requirePrincipal, toResponse } from "@/lib/auth";
 import { stripe } from "@/lib/stripe";
 import { currentUser } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
@@ -12,9 +13,15 @@ export async function POST(
         const routeParams = await params;
 
     try {
-        const user = await currentUser();
+        // Identity comes from the one derivation point (ADR 0001 section 1);
+        // `currentUser` is used only for the email address Stripe needs. This
+        // is a money path, so it must not resolve who is paying a second way.
+        const { userId } = await requirePrincipal();
 
-        if (!user || !user.id || !user.emailAddresses?.[0]?.emailAddress) {
+        const user = await currentUser();
+        const email = user?.emailAddresses?.[0]?.emailAddress;
+
+        if (!email) {
             return new NextResponse("Unauthorized", { status: 401 });
         }
 
@@ -28,7 +35,7 @@ export async function POST(
         const purchase = await db.purchase.findUnique({
             where: {
                 userId_courseId: {
-                    userId: user.id,
+                    userId,
                     courseId: routeParams.courseId
                 }
             }
@@ -58,7 +65,7 @@ export async function POST(
 
         let stripeCustomer = await db.stripCustomer.findUnique({
             where: {
-                userId: user.id,
+                userId,
             },
             select: {
                 stripeCustomerId: true,
@@ -67,12 +74,12 @@ export async function POST(
 
         if (!stripeCustomer) {
             const customer = await stripe.customers.create({
-                email: user.emailAddresses[0].emailAddress,
+                email: email,
             });
 
             stripeCustomer = await db.stripCustomer.create({
                 data: {
-                    userId: user.id,
+                    userId,
                     stripeCustomerId: customer.id,
                 }
             });
@@ -86,12 +93,15 @@ export async function POST(
             cancel_url: `${process.env.NEXT_PUBLIC_APP_URL}/courses/${course.id}?canceled=1`,
             metadata: {
                 courseId: course.id,
-                userId: user.id,
+                userId,
             }
         });
 
         return NextResponse.json({ url: session.url });
     } catch (error) {
+        const denied = toResponse(error);
+        if (denied) return denied;
+
         logError("COURSE_ID_CHECKOUT", error);
         return new NextResponse("Internal Error", { status: 500 });
     }

--- a/app/api/courses/[courseId]/publish/route.ts
+++ b/app/api/courses/[courseId]/publish/route.ts
@@ -1,5 +1,5 @@
 import { db } from "@/lib/db";
-import { auth } from "@clerk/nextjs/server";
+import { requirePrincipal, toResponse } from "@/lib/auth";
 import { NextResponse } from "next/server";
 import { logError } from "@/lib/logger";
 
@@ -10,11 +10,7 @@ export async function PATCH(
         const routeParams = await params;
 
     try {
-        const { userId } = await auth();
-
-        if (!userId) {
-            return new NextResponse("Unauthorized", { status: 401 });
-        }
+        const { userId } = await requirePrincipal();
 
         const course = await db.course.findUnique({
             where: {
@@ -48,6 +44,9 @@ export async function PATCH(
 
         return NextResponse.json(publishedCourse);
     } catch (error) {
+        const denied = toResponse(error);
+        if (denied) return denied;
+
         logError("COURSE_ID_PUBLISH", error);
         return new NextResponse("Internal Error", { status: 500 });
     }

--- a/app/api/courses/[courseId]/quizzes/[quizId]/results/[attemptId]/route.ts
+++ b/app/api/courses/[courseId]/quizzes/[quizId]/results/[attemptId]/route.ts
@@ -1,7 +1,8 @@
-import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 
 import { db } from "@/lib/db";
+import { requirePrincipal, toResponse } from "@/lib/auth";
+import { attemptInQuizAndCourse } from "@/lib/assessments/attempt-access";
 import { logError } from "@/lib/logger";
 
 export async function GET(
@@ -11,14 +12,17 @@ export async function GET(
   const routeParams = await params;
 
   try {
-    const { userId } = await auth();
+    const { userId } = await requirePrincipal();
 
-    if (!userId) {
-      return new NextResponse("Unauthorized", { status: 401 });
-    }
-
-    const attempt = await db.quizAttempt.findUnique({
-      where: { id: routeParams.attemptId },
+    // Bound to the route's Quiz and Course, not just to the caller. An attempt
+    // from one Quiz should not render through another Quiz's URL.
+    const attempt = await db.quizAttempt.findFirst({
+      where: attemptInQuizAndCourse(
+        userId,
+        routeParams.courseId,
+        routeParams.quizId,
+        routeParams.attemptId
+      ),
       include: {
         quiz: {
           select: {
@@ -55,8 +59,8 @@ export async function GET(
       },
     });
 
-    if (!attempt || attempt.userId !== userId) {
-      return new NextResponse("Unauthorized", { status: 401 });
+    if (!attempt) {
+      return new NextResponse("Not Found", { status: 404 });
     }
 
     if (!attempt.completedAt) {
@@ -65,6 +69,9 @@ export async function GET(
 
     return NextResponse.json(attempt);
   } catch (error) {
+    const denied = toResponse(error);
+    if (denied) return denied;
+
     logError("QUIZ_RESULTS", error);
     return new NextResponse("Internal Error", { status: 500 });
   }

--- a/app/api/courses/[courseId]/quizzes/[quizId]/start/route.ts
+++ b/app/api/courses/[courseId]/quizzes/[quizId]/start/route.ts
@@ -1,7 +1,7 @@
-import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 
 import { db } from "@/lib/db";
+import { requirePrincipal, toResponse } from "@/lib/auth";
 import { isPostTestUnlocked } from "@/actions/check-post-test-lock";
 import { logError } from "@/lib/logger";
 
@@ -12,11 +12,7 @@ export async function POST(
   const routeParams = await params;
 
   try {
-    const { userId } = await auth();
-
-    if (!userId) {
-      return new NextResponse("Unauthorized", { status: 401 });
-    }
+    const { userId } = await requirePrincipal();
 
     // Verify enrollment
     const purchase = await db.purchase.findUnique({
@@ -94,6 +90,9 @@ export async function POST(
       questions: quiz.questions,
     });
   } catch (error) {
+    const denied = toResponse(error);
+    if (denied) return denied;
+
     logError("QUIZ_START", error);
     return new NextResponse("Internal Error", { status: 500 });
   }

--- a/app/api/courses/[courseId]/quizzes/[quizId]/submit/route.ts
+++ b/app/api/courses/[courseId]/quizzes/[quizId]/submit/route.ts
@@ -1,9 +1,27 @@
-import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
+import { z } from "zod";
 
 import { db } from "@/lib/db";
+import { requirePrincipal, toResponse } from "@/lib/auth";
+import { findLearnerAttempt } from "@/lib/assessments/attempt-access";
+import { gradeSubmission, validateSubmission } from "@/lib/assessments/grading";
 import { evaluateBadges } from "@/lib/badge-service";
 import { logError } from "@/lib/logger";
+
+const submissionSchema = z.object({
+  attemptId: z.string().min(1),
+  answers: z
+    .array(
+      z.object({
+        questionId: z.string().min(1),
+        selectedOptionId: z.string().min(1),
+      })
+    )
+    // Bounded so a submission cannot be used to write an unlimited number of
+    // rows. A Quiz with more questions than this cannot be graded here, which
+    // is a deliberate ceiling rather than an accident.
+    .max(500),
+});
 
 export async function POST(
   req: Request,
@@ -12,33 +30,32 @@ export async function POST(
   const routeParams = await params;
 
   try {
-    const { userId } = await auth();
+    const { userId } = await requirePrincipal();
 
-    if (!userId) {
-      return new NextResponse("Unauthorized", { status: 401 });
+    const parsed = submissionSchema.safeParse(await req.json());
+    if (!parsed.success) {
+      return new NextResponse("Invalid data", { status: 400 });
     }
+    const { attemptId, answers } = parsed.data;
 
-    const { attemptId, answers } = await req.json() as {
-      attemptId: string;
-      answers: { questionId: string; selectedOptionId: string }[];
-    };
+    // The attempt must be this learner's, on this Quiz, in this Course. It was
+    // previously loaded by id and checked only for ownership, while grading ran
+    // against the route's Quiz -- so an attempt started on one Quiz could be
+    // submitted through another Quiz's URL and scored against questions it was
+    // never issued.
+    const attempt = await findLearnerAttempt(
+      userId,
+      routeParams.courseId,
+      routeParams.quizId,
+      attemptId
+    );
 
-    // Verify attempt belongs to user and is not completed
-    const attempt = await db.quizAttempt.findUnique({
-      where: { id: attemptId },
-      include: {
-        quiz: {
-          select: { timeLimitMinutes: true, passingScore: true },
-        },
-      },
-    });
-
-    if (!attempt || attempt.userId !== userId) {
-      return new NextResponse("Unauthorized", { status: 401 });
+    if (!attempt) {
+      return new NextResponse("Not Found", { status: 404 });
     }
 
     if (attempt.completedAt) {
-      return new NextResponse("Quiz already submitted", { status: 400 });
+      return new NextResponse("Quiz already submitted", { status: 409 });
     }
 
     // Server-side time validation (30s grace period)
@@ -51,8 +68,9 @@ export async function POST(
     }
 
     // Fetch all questions with correct answers
+    // The attempt's own Quiz, which the binding above has proven is the route's.
     const questions = await db.question.findMany({
-      where: { quizId: routeParams.quizId },
+      where: { quizId: attempt.quizId },
       include: {
         options: {
           select: { id: true, isCorrect: true },
@@ -60,70 +78,58 @@ export async function POST(
       },
     });
 
-    // Grade each answer
-    let totalScore = 0;
-    let totalPoints = 0;
-    const results: {
-      questionId: string;
-      correct: boolean;
-      selectedOptionId: string | null;
-      correctOptionId: string;
-    }[] = [];
-
-    for (const question of questions) {
-      const correctOption = question.options.find((o) => o.isCorrect);
-      const userAnswer = answers.find((a) => a.questionId === question.id);
-
-      totalPoints += question.points;
-
-      const isCorrect =
-        userAnswer?.selectedOptionId === correctOption?.id;
-
-      if (isCorrect) {
-        totalScore += question.points;
-      }
-
-      results.push({
-        questionId: question.id,
-        correct: isCorrect,
-        selectedOptionId: userAnswer?.selectedOptionId ?? null,
-        correctOptionId: correctOption?.id ?? "",
-      });
+    // Every submitted Question must belong to this Quiz, every selected option
+    // to that Question, and no Question may be answered twice. Foreign-but-real
+    // ids satisfy the database's foreign keys, so nothing else rejected them.
+    const invalid = validateSubmission(questions, answers);
+    if (invalid) {
+      return new NextResponse("Invalid submission", { status: 400 });
     }
 
-    // Save answers
-    await db.quizAnswer.createMany({
-      data: answers.map((a) => ({
-        attemptId,
-        questionId: a.questionId,
-        selectedOptionId: a.selectedOptionId,
-      })),
+    const { totalScore, totalPoints, percentage, results } = gradeSubmission(
+      questions,
+      answers
+    );
+
+    // Answers and finalisation commit together. The conditional update is what
+    // makes submission idempotent under a double-click or a retry: two
+    // concurrent submissions both pass the completedAt check above, and only
+    // the one that actually flips the row from null commits. #63 replaces this
+    // with a full attempt state machine.
+    const finalised = await db.$transaction(async (tx) => {
+      const claimed = await tx.quizAttempt.updateMany({
+        where: { id: attemptId, completedAt: null },
+        data: {
+          score: totalScore,
+          totalPoints,
+          completedAt: new Date(),
+        },
+      });
+
+      if (claimed.count === 0) return false;
+
+      await tx.quizAnswer.createMany({
+        data: answers.map((a) => ({
+          attemptId,
+          questionId: a.questionId,
+          selectedOptionId: a.selectedOptionId,
+        })),
+      });
+
+      return true;
     });
 
-    // Update attempt
-    await db.quizAttempt.update({
-      where: { id: attemptId },
-      data: {
-        score: totalScore,
-        totalPoints,
-        completedAt: new Date(),
-      },
-    });
-
-    const percentage = totalPoints > 0 ? Math.round((totalScore / totalPoints) * 100) : 0;
+    if (!finalised) {
+      return new NextResponse("Quiz already submitted", { status: 409 });
+    }
 
     // Gamification: evaluate badges on quiz completion
     let preTestScore: number | undefined;
 
     // If this is a post-test, find the pre-test score for growth comparison
-    const quiz = await db.quiz.findUnique({
-      where: { id: routeParams.quizId },
-      select: { type: true, courseId: true },
-    });
-
-    if (quiz?.type === "POST_TEST" && quiz.courseId) {
+    if (attempt.quiz.type === "POST_TEST" && attempt.quiz.courseId) {
       const preTest = await db.quiz.findFirst({
-        where: { courseId: quiz.courseId, type: "PRE_TEST" },
+        where: { courseId: attempt.quiz.courseId, type: "PRE_TEST" },
         select: { id: true },
       });
       if (preTest) {
@@ -162,6 +168,9 @@ export async function POST(
       })),
     });
   } catch (error) {
+    const denied = toResponse(error);
+    if (denied) return denied;
+
     logError("QUIZ_SUBMIT", error);
     return new NextResponse("Internal Error", { status: 500 });
   }

--- a/app/api/courses/[courseId]/unpublish/route.ts
+++ b/app/api/courses/[courseId]/unpublish/route.ts
@@ -1,5 +1,5 @@
 import { db } from "@/lib/db";
-import { auth } from "@clerk/nextjs/server";
+import { requirePrincipal, toResponse } from "@/lib/auth";
 import { NextResponse } from "next/server";
 import { logError } from "@/lib/logger";
 
@@ -10,11 +10,7 @@ export async function PATCH(
         const routeParams = await params;
 
     try {
-        const { userId } = await auth();
-
-        if (!userId) {
-            return new NextResponse("Unauthorized", { status: 401 });
-        }
+        const { userId } = await requirePrincipal();
 
         const course = await db.course.findUnique({
             where: {
@@ -38,6 +34,9 @@ export async function PATCH(
 
         return NextResponse.json(unpublishedCourse);
     } catch (error) {
+        const denied = toResponse(error);
+        if (denied) return denied;
+
         logError("COURSE_ID_UNPUBLISH", error);
         return new NextResponse("Internal Error", { status: 500 });
     }

--- a/app/api/journal/[entryId]/route.ts
+++ b/app/api/journal/[entryId]/route.ts
@@ -1,7 +1,7 @@
-import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 
 import { db } from "@/lib/db";
+import { requirePrincipal, toResponse } from "@/lib/auth";
 import { logError } from "@/lib/logger";
 
 export async function PATCH(
@@ -9,10 +9,7 @@ export async function PATCH(
   { params }: { params: Promise<{ entryId: string }> }
 ) {
   try {
-    const { userId } = await auth();
-    if (!userId) {
-      return new NextResponse("Unauthorized", { status: 401 });
-    }
+    const { userId } = await requirePrincipal();
 
     const { entryId } = await params;
     const values = await req.json();
@@ -43,6 +40,9 @@ export async function PATCH(
 
     return NextResponse.json(updated);
   } catch (error) {
+    const denied = toResponse(error);
+    if (denied) return denied;
+
     logError("JOURNAL_PATCH", error);
     return new NextResponse("Internal Error", { status: 500 });
   }
@@ -53,10 +53,7 @@ export async function DELETE(
   { params }: { params: Promise<{ entryId: string }> }
 ) {
   try {
-    const { userId } = await auth();
-    if (!userId) {
-      return new NextResponse("Unauthorized", { status: 401 });
-    }
+    const { userId } = await requirePrincipal();
 
     const { entryId } = await params;
 
@@ -73,6 +70,9 @@ export async function DELETE(
 
     return new NextResponse(null, { status: 204 });
   } catch (error) {
+    const denied = toResponse(error);
+    if (denied) return denied;
+
     logError("JOURNAL_DELETE", error);
     return new NextResponse("Internal Error", { status: 500 });
   }

--- a/app/api/journal/route.ts
+++ b/app/api/journal/route.ts
@@ -1,15 +1,12 @@
-import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 
 import { db } from "@/lib/db";
+import { requirePrincipal, toResponse } from "@/lib/auth";
 import { logError } from "@/lib/logger";
 
 export async function POST(req: Request) {
   try {
-    const { userId } = await auth();
-    if (!userId) {
-      return new NextResponse("Unauthorized", { status: 401 });
-    }
+    const { userId } = await requirePrincipal();
 
     const { title, content, isPrivate, prompt, moduleId, courseId } =
       await req.json();
@@ -34,6 +31,9 @@ export async function POST(req: Request) {
 
     return NextResponse.json(entry);
   } catch (error) {
+    const denied = toResponse(error);
+    if (denied) return denied;
+
     logError("JOURNAL_POST", error);
     return new NextResponse("Internal Error", { status: 500 });
   }

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -1,16 +1,13 @@
-import { auth } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 
 import { db } from "@/lib/db";
+import { requirePrincipal, toResponse } from "@/lib/auth";
 import { settingsUpdateSchema } from "@/lib/validations/settings";
 import { logError } from "@/lib/logger";
 
 export async function GET() {
   try {
-    const { userId } = await auth();
-    if (!userId) {
-      return new NextResponse("Unauthorized", { status: 401 });
-    }
+    const { userId } = await requirePrincipal();
 
     const settings = await db.userSettings.findUnique({
       where: { userId },
@@ -25,6 +22,9 @@ export async function GET() {
 
     return NextResponse.json(settings);
   } catch (error) {
+    const denied = toResponse(error);
+    if (denied) return denied;
+
     logError("SETTINGS_GET", error);
     return new NextResponse("Internal Error", { status: 500 });
   }
@@ -32,10 +32,7 @@ export async function GET() {
 
 export async function PATCH(req: Request) {
   try {
-    const { userId } = await auth();
-    if (!userId) {
-      return new NextResponse("Unauthorized", { status: 401 });
-    }
+    const { userId } = await requirePrincipal();
 
     const body = await req.json();
 
@@ -55,6 +52,9 @@ export async function PATCH(req: Request) {
 
     return NextResponse.json(settings);
   } catch (error) {
+    const denied = toResponse(error);
+    if (denied) return denied;
+
     logError("SETTINGS_PATCH", error);
     return new NextResponse("Internal Error", { status: 500 });
   }

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -67,6 +67,14 @@ one. The permission matrix in `lib/auth/policy.ts` is held at 100%.
 Adding a module to the list without tests will fail the build. That is the
 intent.
 
+### Identity has one entrance
+
+`getPrincipal`, `requirePrincipal`, and `requirePagePrincipal` in `lib/auth` are
+the only places Clerk's session is read (ADR 0001 §1). An ESLint rule enforces
+it: importing `auth` from `@clerk/nextjs/server` anywhere except `lib/auth/` and
+`proxy.ts` fails the build. `currentUser` stays available for profile data such
+as an email address, but identity itself comes from the principal.
+
 ### Write the negative case first
 
 The failure that matters is rarely "the feature did not work"; it is "the guard

--- a/docs/release/implementation-matrix.md
+++ b/docs/release/implementation-matrix.md
@@ -82,7 +82,7 @@ issue, which is exactly why both documents exist.
 | 2.9 | `/courses/[courseId]` shows expandable modules | `verified` | `app/(dashboard)/(routes)/courses/[courseId]/page.tsx` with `actions/get-course-detail.ts` | |
 | 2.10 | Course player sidebar shows nested modules to topics | `verified` | `app/(course)/courses/[courseId]/_components/course-sidebar-module.tsx` and `app/(course)/courses/[courseId]/_components/course-sidebar-item.tsx` | |
 | 2.11 | Breadcrumbs work throughout course navigation | `verified` | `components/breadcrumb.tsx`, used in the course player layout | |
-| 2.12 | Previous/Next topic navigation, including cross-module | `verified` | Navigation computed across modules in `app/(course)/courses/[courseId]/chapters/[chapterId]/page.tsx` | |
+| 2.12 | Previous/Next topic navigation, including cross-module | `verified` | Navigation computed across modules in `actions/get-topic.ts`, derived from a Topic bound to the Course through its Module by `lib/courses/topic-access.ts` | [#39](https://github.com/akomapahealth/akomapa-lms/issues/39) |
 | 2.13 | Module completion triggers celebration | `partial` | `components/providers/confetti-provider.tsx` fires from `app/(course)/courses/[courseId]/chapters/[chapterId]/_components/video-player.tsx` on video end, which is topic completion, not module completion | [#59](https://github.com/akomapahealth/akomapa-lms/issues/59) |
 | 2.14 | All pages responsive on mobile | `partial` | Responsive classes are used throughout and the shell has a mobile nav, but no route-by-route audit has been performed | [#95](https://github.com/akomapahealth/akomapa-lms/issues/95), [#98](https://github.com/akomapahealth/akomapa-lms/issues/98) |
 | 2.15 | `npm run build` succeeds | `verified` | Build job green in CI | |

--- a/lib/assessments/attempt-access.ts
+++ b/lib/assessments/attempt-access.ts
@@ -1,0 +1,45 @@
+import "server-only";
+
+import { db } from "@/lib/db";
+
+/**
+ * The Course → Quiz → Attempt relationship (#41).
+ *
+ * The submit route checked only that the attempt belonged to the caller, then
+ * graded against the questions of the Quiz named in the *route*. Those are two
+ * different Quizzes whenever the caller says so: an attempt started on one Quiz
+ * could be submitted through another Quiz's URL, scoring the attempt against
+ * questions it was never issued.
+ *
+ * Ownership and membership are asserted together, in the query.
+ */
+export function attemptInQuizAndCourse(
+  userId: string,
+  courseId: string,
+  quizId: string,
+  attemptId: string
+) {
+  return {
+    id: attemptId,
+    userId,
+    quizId,
+    quiz: { courseId },
+  } as const;
+}
+
+/** Loads an attempt only if it is the learner's, on this Quiz, in this Course. */
+export async function findLearnerAttempt(
+  userId: string,
+  courseId: string,
+  quizId: string,
+  attemptId: string
+) {
+  return db.quizAttempt.findFirst({
+    where: attemptInQuizAndCourse(userId, courseId, quizId, attemptId),
+    include: {
+      quiz: {
+        select: { timeLimitMinutes: true, passingScore: true, type: true, courseId: true },
+      },
+    },
+  });
+}

--- a/lib/assessments/grading.ts
+++ b/lib/assessments/grading.ts
@@ -1,0 +1,124 @@
+/**
+ * Grading and submission validation.
+ *
+ * Pure: no database, no clock. Grading determines a score that feeds
+ * certificates and analytics, so the rules are worth testing directly rather
+ * than inferring from a route handler.
+ */
+
+export interface GradableOption {
+  id: string;
+  isCorrect: boolean;
+}
+
+export interface GradableQuestion {
+  id: string;
+  points: number;
+  options: GradableOption[];
+}
+
+export interface SubmittedAnswer {
+  questionId: string;
+  selectedOptionId: string;
+}
+
+export type ValidationFailure =
+  | { reason: "duplicate_question"; questionId: string }
+  | { reason: "unknown_question"; questionId: string }
+  | { reason: "option_not_in_question"; questionId: string };
+
+/**
+ * Rejects a submission whose shape does not match the Quiz being graded.
+ *
+ * Answers arrived unvalidated: nothing checked that a `questionId` belonged to
+ * this Quiz, that a `selectedOptionId` belonged to that Question, or that a
+ * Question was answered only once. Foreign-but-real ids satisfy the database's
+ * foreign keys, so they were written and graded without complaint.
+ */
+export function validateSubmission(
+  questions: GradableQuestion[],
+  answers: SubmittedAnswer[]
+): ValidationFailure | null {
+  const byId = new Map(questions.map((question) => [question.id, question]));
+  const seen = new Set<string>();
+
+  for (const answer of answers) {
+    if (seen.has(answer.questionId)) {
+      return { reason: "duplicate_question", questionId: answer.questionId };
+    }
+    seen.add(answer.questionId);
+
+    const question = byId.get(answer.questionId);
+    if (!question) {
+      return { reason: "unknown_question", questionId: answer.questionId };
+    }
+
+    if (!question.options.some((option) => option.id === answer.selectedOptionId)) {
+      return { reason: "option_not_in_question", questionId: answer.questionId };
+    }
+  }
+
+  return null;
+}
+
+export interface GradedAnswer {
+  questionId: string;
+  correct: boolean;
+  selectedOptionId: string | null;
+  correctOptionId: string;
+}
+
+export interface Grade {
+  totalScore: number;
+  totalPoints: number;
+  percentage: number;
+  results: GradedAnswer[];
+}
+
+/**
+ * Grades a validated submission against the Quiz's own questions.
+ *
+ * Every question in the Quiz contributes to `totalPoints`, answered or not, so
+ * skipping a question cannot raise the percentage.
+ */
+export function gradeSubmission(
+  questions: GradableQuestion[],
+  answers: SubmittedAnswer[]
+): Grade {
+  const byQuestion = new Map(answers.map((answer) => [answer.questionId, answer]));
+
+  let totalScore = 0;
+  let totalPoints = 0;
+  const results: GradedAnswer[] = [];
+
+  for (const question of questions) {
+    const correctOption = question.options.find((option) => option.isCorrect);
+    const submitted = byQuestion.get(question.id);
+
+    totalPoints += question.points;
+
+    // A Question with no correct option cannot be answered correctly. Comparing
+    // `undefined === undefined` would otherwise mark an unanswered Question on a
+    // misconfigured Quiz as correct. #65 stops such a Quiz being published.
+    const correct =
+      correctOption !== undefined &&
+      submitted !== undefined &&
+      submitted.selectedOptionId === correctOption.id;
+
+    if (correct) totalScore += question.points;
+
+    results.push({
+      questionId: question.id,
+      correct,
+      selectedOptionId: submitted?.selectedOptionId ?? null,
+      correctOptionId: correctOption?.id ?? "",
+    });
+  }
+
+  return {
+    totalScore,
+    totalPoints,
+    percentage: totalPoints > 0 ? Math.round((totalScore / totalPoints) * 100) : 0,
+    results,
+  };
+}

--- a/lib/auth/guards.ts
+++ b/lib/auth/guards.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { db } from "@/lib/db";
+import { topicInCourse } from "@/lib/courses/topic-access";
 
 import type { Action } from "./actions";
 import { Denied } from "./errors";
@@ -132,6 +133,30 @@ export async function authorizeQuestionInCourse(
 
   if (!question) throw new Denied("not_found", action);
   return question;
+}
+
+/**
+ * Loads a Topic for authoring, asserting Course -> Module -> Topic.
+ *
+ * Publication is not filtered here: staff work on unpublished content. The
+ * Course binding is what matters -- the authoring routes previously confirmed
+ * Course ownership and then loaded the Topic by id alone, so an owner of one
+ * Course could edit, publish, or delete a Topic in another.
+ */
+export async function authorizeTopicInCourse(
+  principal: Principal,
+  action: Action,
+  courseId: string,
+  topicId: string
+) {
+  await authorizeCourse(principal, action, courseId);
+
+  const topic = await db.topic.findFirst({
+    where: topicInCourse(courseId, topicId),
+  });
+
+  if (!topic) throw new Denied("not_found", action);
+  return topic;
 }
 
 /**

--- a/lib/auth/index.ts
+++ b/lib/auth/index.ts
@@ -37,6 +37,7 @@ export {
   getStaffCapabilities,
   NO_STAFF_CAPABILITIES,
   requirePageCapability,
+  requirePagePrincipal,
   requirePageCourse,
   type StaffCapabilities,
 } from "./page";

--- a/lib/auth/index.ts
+++ b/lib/auth/index.ts
@@ -30,6 +30,7 @@ export {
   authorizePost,
   authorizeQuestionInCourse,
   authorizeQuizInCourse,
+  authorizeTopicInCourse,
   requireCapability,
 } from "./guards";
 export {

--- a/lib/auth/page.ts
+++ b/lib/auth/page.ts
@@ -21,6 +21,21 @@ import { getPrincipal } from "./principal";
  * all, so any faculty member reached every administration page.
  */
 
+/**
+ * The principal for a page, or a redirect.
+ *
+ * For pages that need to know who is calling but have no capability to check --
+ * a learner's own dashboard, journal, or grades. Callers pass the destination
+ * their old `auth()` guard used, so behaviour does not change with the seam.
+ */
+export async function requirePagePrincipal(
+  redirectTo = "/sign-in"
+): Promise<Principal> {
+  const principal = await getPrincipal();
+  if (!principal) redirect(redirectTo);
+  return principal;
+}
+
 /** Requires a capability that needs no resource. Redirects rather than throwing. */
 export async function requirePageCapability(action: Action): Promise<Principal> {
   const principal = await getPrincipal();

--- a/lib/courses/completion.ts
+++ b/lib/courses/completion.ts
@@ -1,0 +1,62 @@
+/**
+ * Completion rules.
+ *
+ * Pure: no database, no clock. Completion decides whether a certificate is
+ * issued, which is the product's only externally verifiable claim, so the rule
+ * is worth being able to test exhaustively rather than inferring from a route
+ * handler.
+ *
+ * The rule that matters is that completion is **non-vacuous**. `[].every()` is
+ * `true`, so a Course with no published Topics -- a draft, or one whose Topics
+ * were all unpublished -- satisfied a naive check and issued a certificate for
+ * finishing nothing. Emptiness is not completion.
+ *
+ * #59 owns the fuller definition (prerequisites, required vs optional Topics);
+ * this is the invariant that must hold under any of them.
+ */
+
+export interface TopicCompletion {
+  id: string;
+  completed: boolean;
+}
+
+export interface ModuleCompletion {
+  topics: TopicCompletion[];
+}
+
+/**
+ * Treats `justCompletedId` as complete regardless of what was read.
+ *
+ * The progress write and the completion read are separate statements, so the
+ * row for the Topic being completed may still show its old value. Passing the
+ * id explicitly avoids depending on read-after-write ordering. #49 makes the
+ * whole sequence one transaction.
+ */
+function isDone(topic: TopicCompletion, justCompletedId: string): boolean {
+  return topic.id === justCompletedId || topic.completed;
+}
+
+/** A Module is complete when it has at least one Topic and all of them are done. */
+export function isModuleComplete(
+  courseModule: ModuleCompletion,
+  justCompletedId: string
+): boolean {
+  if (courseModule.topics.length === 0) return false;
+  return courseModule.topics.every((topic) => isDone(topic, justCompletedId));
+}
+
+/**
+ * A Course is complete when it has at least one published Topic and every one
+ * of them is done.
+ *
+ * Counting Topics rather than Modules means a Module that happens to hold no
+ * published Topics neither blocks completion nor manufactures it.
+ */
+export function isCourseComplete(
+  modules: ModuleCompletion[],
+  justCompletedId: string
+): boolean {
+  const topics = modules.flatMap((courseModule) => courseModule.topics);
+  if (topics.length === 0) return false;
+  return topics.every((topic) => isDone(topic, justCompletedId));
+}

--- a/lib/courses/topic-access.ts
+++ b/lib/courses/topic-access.ts
@@ -1,0 +1,79 @@
+import "server-only";
+
+import { db } from "@/lib/db";
+
+/**
+ * The Course → Module → Topic relationship, asserted in one place.
+ *
+ * A Topic id in a URL proves nothing about which Course it belongs to. Loading
+ * a Topic by id alone and trusting the Course id that arrived beside it is the
+ * defect in #39: substituting another Course's Topic id into a purchased
+ * Course's URL returned that Topic's content, and because the entitlement check
+ * looked at the *URL's* Course, owning one Course unlocked video in another.
+ *
+ * The relationship is expressed as a `where` fragment rather than a check that
+ * runs after a query, so it cannot be forgotten at a call site and cannot be
+ * true-but-unused. Every learner and authoring path that accepts a Topic id
+ * composes one of these.
+ */
+
+/**
+ * A Topic that is visible to a learner: published, in a published Module, in
+ * the named Course.
+ *
+ * Publication is part of the relationship, not a separate concern. An
+ * unpublished Module must not expose its Topics even when the Topic itself is
+ * published, or withdrawing a Module from learners would not actually withdraw
+ * anything.
+ */
+export function publishedTopicInCourse(courseId: string, topicId: string) {
+  return {
+    id: topicId,
+    isPublished: true,
+    module: {
+      courseId,
+      isPublished: true,
+    },
+  } as const;
+}
+
+/**
+ * A Topic in the named Course regardless of publication state, for authoring.
+ *
+ * Staff work on unpublished content by definition, so this omits the
+ * publication filter — but never the Course binding.
+ */
+export function topicInCourse(courseId: string, topicId: string) {
+  return {
+    id: topicId,
+    module: { courseId },
+  } as const;
+}
+
+/** Loads a learner-visible Topic, or null when it does not belong to the Course. */
+export async function findPublishedTopicInCourse(
+  courseId: string,
+  topicId: string
+) {
+  return db.topic.findFirst({
+    where: publishedTopicInCourse(courseId, topicId),
+    include: { module: true },
+  });
+}
+
+/**
+ * Does this Topic belong to this Course at all?
+ *
+ * Used by mutations that need the relationship but not the row, so that a
+ * progress write cannot be aimed at a Topic in a Course the learner is not on.
+ */
+export async function topicBelongsToCourse(
+  courseId: string,
+  topicId: string
+): Promise<boolean> {
+  const found = await db.topic.findFirst({
+    where: topicInCourse(courseId, topicId),
+    select: { id: true },
+  });
+  return found !== null;
+}

--- a/tests/unit/assessments/attempt-access.test.ts
+++ b/tests/unit/assessments/attempt-access.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { dbMock } from "../support/db";
+
+vi.mock("@/lib/db", async () => ({ db: (await import("../support/db")).dbMock }));
+
+const { attemptInQuizAndCourse, findLearnerAttempt } = await import(
+  "@/lib/assessments/attempt-access"
+);
+
+/**
+ * Course → Quiz → Attempt (#41).
+ *
+ * The submit route checked only that the attempt belonged to the caller, then
+ * graded against the questions of the Quiz named in the *route*. Those are
+ * different Quizzes whenever the caller says so.
+ */
+describe("attemptInQuizAndCourse", () => {
+  it("binds the attempt to the learner, the Quiz, and the Course at once", () => {
+    expect(attemptInQuizAndCourse("user_1", "course_1", "quiz_1", "attempt_1")).toEqual({
+      id: "attempt_1",
+      userId: "user_1",
+      quizId: "quiz_1",
+      quiz: { courseId: "course_1" },
+    });
+  });
+
+  it("never binds by id and owner alone", () => {
+    // Ownership without membership is the defect: the attempt was the caller's,
+    // but not necessarily on the Quiz being graded.
+    const where = attemptInQuizAndCourse("user_1", "course_1", "quiz_1", "attempt_1");
+
+    expect(where.quizId).toBe("quiz_1");
+    expect(where.quiz.courseId).toBe("course_1");
+  });
+});
+
+describe("findLearnerAttempt", () => {
+  it("queries with the full relationship asserted", async () => {
+    dbMock.quizAttempt.findFirst.mockResolvedValue({ id: "attempt_1", quizId: "quiz_1" });
+
+    await findLearnerAttempt("user_1", "course_1", "quiz_1", "attempt_1");
+
+    expect(dbMock.quizAttempt.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          id: "attempt_1",
+          userId: "user_1",
+          quizId: "quiz_1",
+          quiz: { courseId: "course_1" },
+        },
+      })
+    );
+  });
+
+  it("returns null for another learner's attempt", async () => {
+    dbMock.quizAttempt.findFirst.mockResolvedValue(null);
+
+    await expect(findLearnerAttempt("user_2", "course_1", "quiz_1", "attempt_1"))
+      .resolves.toBeNull();
+  });
+
+  it("returns null for the learner's own attempt submitted through the wrong Quiz", async () => {
+    dbMock.quizAttempt.findFirst.mockResolvedValue(null);
+
+    await expect(findLearnerAttempt("user_1", "course_1", "quiz_OTHER", "attempt_1"))
+      .resolves.toBeNull();
+  });
+
+  it("uses findFirst, since findUnique cannot express the relationship", async () => {
+    dbMock.quizAttempt.findFirst.mockResolvedValue({ id: "attempt_1" });
+
+    await findLearnerAttempt("user_1", "course_1", "quiz_1", "attempt_1");
+
+    expect(dbMock.quizAttempt.findUnique).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/assessments/grading.test.ts
+++ b/tests/unit/assessments/grading.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  gradeSubmission,
+  validateSubmission,
+  type GradableQuestion,
+} from "@/lib/assessments/grading";
+
+/**
+ * Submission validation and grading (#41).
+ *
+ * Answers arrived entirely unvalidated: nothing checked that a `questionId`
+ * belonged to the Quiz being graded, that a `selectedOptionId` belonged to that
+ * Question, or that a Question was answered only once. Foreign-but-real ids
+ * satisfy the database's foreign keys, so they were written and graded without
+ * complaint.
+ */
+const question = (
+  id: string,
+  correctId: string,
+  points = 1
+): GradableQuestion => ({
+  id,
+  points,
+  options: [
+    { id: `${id}_a`, isCorrect: `${id}_a` === correctId },
+    { id: `${id}_b`, isCorrect: `${id}_b` === correctId },
+  ],
+});
+
+const QUIZ = [question("q1", "q1_a"), question("q2", "q2_b", 3)];
+
+describe("validateSubmission", () => {
+  it("accepts a well-formed submission", () => {
+    expect(
+      validateSubmission(QUIZ, [
+        { questionId: "q1", selectedOptionId: "q1_a" },
+        { questionId: "q2", selectedOptionId: "q2_b" },
+      ])
+    ).toBeNull();
+  });
+
+  it("accepts an empty submission, which scores zero rather than failing", () => {
+    expect(validateSubmission(QUIZ, [])).toBeNull();
+  });
+
+  it("rejects a Question that is not in this Quiz", () => {
+    // The id may well exist -- in another Quiz. Foreign keys do not care.
+    expect(
+      validateSubmission(QUIZ, [{ questionId: "q_from_other_quiz", selectedOptionId: "q1_a" }])
+    ).toEqual({ reason: "unknown_question", questionId: "q_from_other_quiz" });
+  });
+
+  it("rejects an option that belongs to a different Question", () => {
+    expect(
+      validateSubmission(QUIZ, [{ questionId: "q1", selectedOptionId: "q2_a" }])
+    ).toEqual({ reason: "option_not_in_question", questionId: "q1" });
+  });
+
+  it("rejects an option that does not exist", () => {
+    expect(
+      validateSubmission(QUIZ, [{ questionId: "q1", selectedOptionId: "made_up" }])
+    ).toEqual({ reason: "option_not_in_question", questionId: "q1" });
+  });
+
+  it("rejects the same Question answered twice", () => {
+    // Two answers for one Question would both be written, and the grader would
+    // silently use whichever it found first.
+    expect(
+      validateSubmission(QUIZ, [
+        { questionId: "q1", selectedOptionId: "q1_a" },
+        { questionId: "q1", selectedOptionId: "q1_b" },
+      ])
+    ).toEqual({ reason: "duplicate_question", questionId: "q1" });
+  });
+});
+
+describe("gradeSubmission", () => {
+  it("awards a question's points only for the correct option", () => {
+    const grade = gradeSubmission(QUIZ, [
+      { questionId: "q1", selectedOptionId: "q1_a" },
+      { questionId: "q2", selectedOptionId: "q2_a" },
+    ]);
+
+    expect(grade.totalScore).toBe(1);
+    expect(grade.totalPoints).toBe(4);
+    expect(grade.percentage).toBe(25);
+  });
+
+  it("counts every Question toward the total, answered or not", () => {
+    // Skipping a Question must not raise the percentage by shrinking the
+    // denominator.
+    const grade = gradeSubmission(QUIZ, [{ questionId: "q1", selectedOptionId: "q1_a" }]);
+
+    expect(grade.totalPoints).toBe(4);
+    expect(grade.percentage).toBe(25);
+  });
+
+  it("scores an empty submission as zero, not as complete", () => {
+    const grade = gradeSubmission(QUIZ, []);
+
+    expect(grade).toMatchObject({ totalScore: 0, totalPoints: 4, percentage: 0 });
+  });
+
+  it("reports which option was correct alongside what was chosen", () => {
+    const grade = gradeSubmission(QUIZ, [{ questionId: "q1", selectedOptionId: "q1_b" }]);
+
+    expect(grade.results[0]).toEqual({
+      questionId: "q1",
+      correct: false,
+      selectedOptionId: "q1_b",
+      correctOptionId: "q1_a",
+    });
+    expect(grade.results[1].selectedOptionId).toBeNull();
+  });
+
+  it("does not mark an unanswered Question correct when it has no correct option", () => {
+    // The original comparison was `userAnswer?.selectedOptionId === correctOption?.id`,
+    // which is `undefined === undefined` -- true -- for an unanswered Question on
+    // a Quiz where nobody marked an option correct. That awarded free points.
+    // #65 stops such a Quiz being published; grading must not reward it either.
+    const broken: GradableQuestion[] = [
+      { id: "q1", points: 5, options: [{ id: "q1_a", isCorrect: false }] },
+    ];
+
+    const grade = gradeSubmission(broken, []);
+
+    expect(grade.results[0].correct).toBe(false);
+    expect(grade.totalScore).toBe(0);
+  });
+
+  it("rounds the percentage to a whole number", () => {
+    const thirds = [question("a", "a_a"), question("b", "b_a"), question("c", "c_a")];
+
+    const grade = gradeSubmission(thirds, [{ questionId: "a", selectedOptionId: "a_a" }]);
+
+    expect(grade.percentage).toBe(33);
+  });
+
+  it("reports zero rather than dividing by zero for a Quiz with no Questions", () => {
+    expect(gradeSubmission([], [])).toMatchObject({ totalPoints: 0, percentage: 0 });
+  });
+});

--- a/tests/unit/auth/guards.test.ts
+++ b/tests/unit/auth/guards.test.ts
@@ -13,6 +13,7 @@ const {
   authorizePost,
   authorizeQuestionInCourse,
   authorizeQuizInCourse,
+  authorizeTopicInCourse,
   requireCapability,
 } = await import("@/lib/auth/guards");
 const { Denied } = await import("@/lib/auth/errors");
@@ -212,6 +213,45 @@ describe("authorizeQuestionInCourse", () => {
       )
     ).toBe("forbidden");
     expect(dbMock.question.findFirst).not.toHaveBeenCalled();
+  });
+});
+
+describe("authorizeTopicInCourse", () => {
+  beforeEach(() => {
+    dbMock.course.findFirst.mockResolvedValue({ id: "course_1", userId: "user_owner" });
+    dbMock.topic.findFirst.mockResolvedValue({ id: "topic_1", moduleId: "module_1" });
+  });
+
+  it("binds the Topic to the Course through its Module", async () => {
+    await authorizeTopicInCourse(faculty, "topic:update", "course_1", "topic_1");
+
+    expect(dbMock.topic.findFirst).toHaveBeenCalledWith({
+      where: { id: "topic_1", module: { courseId: "course_1" } },
+    });
+  });
+
+  it("does not filter on publication, because staff author unpublished Topics", async () => {
+    await authorizeTopicInCourse(faculty, "topic:update", "course_1", "topic_1");
+
+    const where = dbMock.topic.findFirst.mock.calls[0][0].where;
+    expect(where).not.toHaveProperty("isPublished");
+  });
+
+  it("refuses a Topic in another Course even when the principal owns this one", async () => {
+    // The authoring routes confirmed Course ownership and then loaded the Topic
+    // by id alone, so owning any Course reached a Topic in any other.
+    dbMock.topic.findFirst.mockResolvedValue(null);
+
+    expect(
+      await reasonFor(authorizeTopicInCourse(faculty, "topic:delete", "course_1", "topic_9"))
+    ).toBe("not_found");
+  });
+
+  it("refuses a learner before touching the Topic", async () => {
+    expect(
+      await reasonFor(authorizeTopicInCourse(student, "topic:delete", "course_1", "topic_1"))
+    ).toBe("forbidden");
+    expect(dbMock.topic.findFirst).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/unit/auth/page.test.ts
+++ b/tests/unit/auth/page.test.ts
@@ -19,8 +19,12 @@ vi.mock("@clerk/nextjs/server", () => ({ auth: clerkAuth }));
 vi.mock("next/navigation", () => nav);
 vi.mock("@/lib/db", async () => ({ db: (await import("../support/db")).dbMock }));
 
-const { getStaffCapabilities, requirePageCapability, requirePageCourse } =
-  await import("@/lib/auth/page");
+const {
+  getStaffCapabilities,
+  requirePageCapability,
+  requirePageCourse,
+  requirePagePrincipal,
+} = await import("@/lib/auth/page");
 
 /**
  * Page-level authorization.
@@ -37,6 +41,35 @@ function signedInAs(userId: string | null, role?: string) {
 
 beforeEach(() => {
   signedInAs("user_1", "FACULTY");
+});
+
+describe("requirePagePrincipal", () => {
+  it("returns the principal when there is a session", async () => {
+    await expect(requirePagePrincipal()).resolves.toEqual({
+      userId: "user_1",
+      role: "FACULTY",
+    });
+  });
+
+  it("sends an anonymous visitor to sign in by default", async () => {
+    signedInAs(null);
+
+    await expect(requirePagePrincipal()).rejects.toThrow("REDIRECT:/sign-in");
+  });
+
+  it("honours the destination the page's old guard used", async () => {
+    // Several pages sent an anonymous visitor to /dashboard rather than
+    // /sign-in. Preserving each destination keeps the seam behaviour-neutral.
+    signedInAs(null);
+
+    await expect(requirePagePrincipal("/dashboard")).rejects.toThrow("REDIRECT:/dashboard");
+  });
+
+  it("does not check any capability, so a learner passes", async () => {
+    signedInAs("user_1", "STUDENT");
+
+    await expect(requirePagePrincipal()).resolves.toMatchObject({ role: "STUDENT" });
+  });
 });
 
 describe("requirePageCapability", () => {

--- a/tests/unit/courses/completion.test.ts
+++ b/tests/unit/courses/completion.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import { isCourseComplete, isModuleComplete } from "@/lib/courses/completion";
+
+/**
+ * Completion decides whether a certificate is issued, which is the product's
+ * only externally verifiable claim. The rule that matters most is the negative
+ * one: emptiness is not completion.
+ *
+ * Before #40 both checks were a bare `.every()`. `[].every()` is `true`, so a
+ * Course with no published Topics -- a draft, or one whose Topics had all been
+ * unpublished -- reported complete, marked the Enrollment COMPLETED, and issued
+ * a certificate for finishing nothing.
+ */
+const done = (id: string) => ({ id, completed: true });
+const pending = (id: string) => ({ id, completed: false });
+
+describe("isModuleComplete", () => {
+  it("is false for a Module with no published Topics", () => {
+    expect(isModuleComplete({ topics: [] }, "topic_1")).toBe(false);
+  });
+
+  it("is true when every Topic is done", () => {
+    expect(isModuleComplete({ topics: [done("a"), done("b")] }, "none")).toBe(true);
+  });
+
+  it("is false when any Topic is outstanding", () => {
+    expect(isModuleComplete({ topics: [done("a"), pending("b")] }, "none")).toBe(false);
+  });
+
+  it("counts the Topic being completed right now", () => {
+    // The progress write and this read are separate statements, so the row for
+    // the Topic just completed may still show its old value.
+    expect(isModuleComplete({ topics: [done("a"), pending("b")] }, "b")).toBe(true);
+  });
+
+  it("does not count a Topic id that is not in the Module", () => {
+    // A mismatched id must not be able to complete a Module it has nothing to
+    // do with.
+    expect(isModuleComplete({ topics: [pending("a")] }, "topic_from_elsewhere")).toBe(false);
+  });
+
+  it("is true for a single completed Topic", () => {
+    expect(isModuleComplete({ topics: [pending("a")] }, "a")).toBe(true);
+  });
+});
+
+describe("isCourseComplete", () => {
+  it("is false for a Course with no Modules", () => {
+    expect(isCourseComplete([], "topic_1")).toBe(false);
+  });
+
+  it("is false for a Course whose Modules hold no published Topics", () => {
+    // The vacuous case that issued certificates for empty Courses.
+    expect(isCourseComplete([{ topics: [] }, { topics: [] }], "topic_1")).toBe(false);
+  });
+
+  it("is true when every Topic across every Module is done", () => {
+    expect(
+      isCourseComplete([{ topics: [done("a")] }, { topics: [done("b"), done("c")] }], "none")
+    ).toBe(true);
+  });
+
+  it("is false when one Topic in one Module is outstanding", () => {
+    expect(
+      isCourseComplete([{ topics: [done("a")] }, { topics: [done("b"), pending("c")] }], "none")
+    ).toBe(false);
+  });
+
+  it("counts the Topic being completed right now", () => {
+    expect(
+      isCourseComplete([{ topics: [done("a")] }, { topics: [pending("b")] }], "b")
+    ).toBe(true);
+  });
+
+  it("ignores an empty Module rather than letting it block or manufacture completion", () => {
+    // Counting Topics rather than Modules means a Module that happens to hold
+    // no published Topics does neither.
+    expect(isCourseComplete([{ topics: [done("a")] }, { topics: [] }], "none")).toBe(true);
+  });
+
+  it("does not let a Topic from another Course complete this one", () => {
+    expect(isCourseComplete([{ topics: [pending("a")] }, { topics: [pending("b")] }], "foreign"))
+      .toBe(false);
+  });
+});

--- a/tests/unit/courses/get-topic.test.ts
+++ b/tests/unit/courses/get-topic.test.ts
@@ -1,0 +1,247 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { dbMock } from "../support/db";
+
+vi.mock("@/lib/db", async () => ({ db: (await import("../support/db")).dbMock }));
+
+const { getTopic } = await import("@/actions/get-topic");
+
+/**
+ * The regression matrix for #39.
+ *
+ * The defect: `getTopic` loaded the Topic by id alone and then gated content on
+ * a purchase of the Course named in the *URL*. Substituting a Topic id from
+ * another Course into a purchased Course's URL therefore returned that Topic --
+ * and because the purchase check passed, its video and attachments too. Owning
+ * one Course unlocked content in every other.
+ */
+/**
+ * A Topic that genuinely exists -- in a *different* Course.
+ *
+ * The double models both lookups faithfully: `findUnique` by id returns it
+ * regardless of Course (which is exactly what the old code asked for and got),
+ * while `findFirst` honours the Course binding. So restoring the original query
+ * makes these tests fail, which is the only way they are worth having.
+ */
+const FOREIGN_TOPIC = {
+  id: "topic_from_course_2",
+  moduleId: "module_2",
+  position: 1,
+  isFree: false,
+  isPublished: true,
+  module: { id: "module_2", courseId: "course_2", position: 1 },
+};
+
+function foreignTopicExists() {
+  dbMock.topic.findUnique.mockResolvedValue(FOREIGN_TOPIC);
+  dbMock.topic.findFirst.mockImplementation(
+    async (args: { where?: { module?: { courseId?: string } } }) =>
+      args?.where?.module?.courseId === FOREIGN_TOPIC.module.courseId
+        ? FOREIGN_TOPIC
+        : null
+  );
+}
+
+function courseExists(price: number | null = 0) {
+  dbMock.course.findUnique.mockResolvedValue({ price });
+}
+
+function topicResolves(overrides: Record<string, unknown> = {}) {
+  dbMock.topic.findFirst.mockResolvedValue({
+    id: "topic_1",
+    moduleId: "module_1",
+    position: 1,
+    isFree: false,
+    isPublished: true,
+    module: { id: "module_1", courseId: "course_1", position: 1 },
+    ...overrides,
+  });
+}
+
+beforeEach(() => {
+  courseExists();
+  dbMock.muxData.findUnique.mockResolvedValue({ id: "mux_1", playbackId: "pb_1" });
+  dbMock.attachment.findMany.mockResolvedValue([{ id: "att_1" }]);
+});
+
+describe("a Topic from another Course", () => {
+  beforeEach(() => {
+    foreignTopicExists();
+    // The learner legitimately owns the Course named in the URL.
+    dbMock.purchase.findUnique.mockResolvedValue({ id: "purchase_1" });
+  });
+
+  it("cannot be loaded by substituting its id into a purchased Course URL", async () => {
+    const result = await getTopic({
+      userId: "user_1",
+      courseId: "course_1",
+      topicId: FOREIGN_TOPIC.id,
+    });
+
+    expect(result.topic).toBeNull();
+  });
+
+  it("returns no video even though the learner owns the Course in the URL", async () => {
+    // The heart of the defect: the purchase was for course_1, the content was
+    // from course_2, and the entitlement check never noticed the difference.
+    const result = await getTopic({
+      userId: "user_1",
+      courseId: "course_1",
+      topicId: FOREIGN_TOPIC.id,
+    });
+
+    expect(result.muxData).toBeNull();
+    expect(result.attachments).toEqual([]);
+  });
+
+  it("returns no navigation derived from the foreign Topic", async () => {
+    const result = await getTopic({
+      userId: "user_1",
+      courseId: "course_1",
+      topicId: FOREIGN_TOPIC.id,
+    });
+
+    expect(result.nextTopic).toBeNull();
+    expect(result.previousTopic).toBeNull();
+  });
+
+  it("is still reachable from its own Course, so the binding is not simply blocking everything", async () => {
+    const result = await getTopic({
+      userId: "user_1",
+      courseId: "course_2",
+      topicId: FOREIGN_TOPIC.id,
+    });
+
+    expect(result.topic).not.toBeNull();
+  });
+});
+
+describe("the query that enforces it", () => {
+  it("asks for the Topic through its Module and Course", async () => {
+    topicResolves();
+    dbMock.purchase.findUnique.mockResolvedValue(null);
+
+    await getTopic({ userId: "user_1", courseId: "course_1", topicId: "topic_1" });
+
+    expect(dbMock.topic.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          id: "topic_1",
+          isPublished: true,
+          module: { courseId: "course_1", isPublished: true },
+        },
+      })
+    );
+  });
+
+  it("requires the Course itself to be published", async () => {
+    topicResolves();
+    dbMock.purchase.findUnique.mockResolvedValue(null);
+
+    await getTopic({ userId: "user_1", courseId: "course_1", topicId: "topic_1" });
+
+    expect(dbMock.course.findUnique).toHaveBeenCalledWith({
+      where: { isPublished: true, id: "course_1" },
+      select: { price: true },
+    });
+  });
+});
+
+describe("entitlement within the correct Course", () => {
+  beforeEach(() => {
+    dbMock.topic.findFirst.mockResolvedValue({
+      id: "topic_1",
+      moduleId: "module_1",
+      position: 1,
+      isFree: false,
+      isPublished: true,
+      module: { id: "module_1", courseId: "course_1", position: 1 },
+    });
+  });
+
+  it("withholds video and attachments from a learner who has not purchased", async () => {
+    dbMock.purchase.findUnique.mockResolvedValue(null);
+
+    const result = await getTopic({
+      userId: "user_1",
+      courseId: "course_1",
+      topicId: "topic_1",
+    });
+
+    expect(result.topic).not.toBeNull();
+    expect(result.muxData).toBeNull();
+    expect(result.attachments).toEqual([]);
+  });
+
+  it("releases video to a purchaser", async () => {
+    dbMock.purchase.findUnique.mockResolvedValue({ id: "purchase_1" });
+
+    const result = await getTopic({
+      userId: "user_1",
+      courseId: "course_1",
+      topicId: "topic_1",
+    });
+
+    expect(result.muxData).not.toBeNull();
+    expect(result.attachments).toHaveLength(1);
+  });
+
+  it("releases video for a free-preview Topic without a purchase, but not attachments", async () => {
+    dbMock.topic.findFirst.mockResolvedValue({
+      id: "topic_1",
+      moduleId: "module_1",
+      position: 1,
+      isFree: true,
+      isPublished: true,
+      module: { id: "module_1", courseId: "course_1", position: 1 },
+    });
+    dbMock.purchase.findUnique.mockResolvedValue(null);
+
+    const result = await getTopic({
+      userId: "user_1",
+      courseId: "course_1",
+      topicId: "topic_1",
+    });
+
+    expect(result.muxData).not.toBeNull();
+    // Attachments are course materials, not preview content.
+    expect(result.attachments).toEqual([]);
+  });
+
+  it("scopes the purchase lookup to this learner and this Course", async () => {
+    dbMock.purchase.findUnique.mockResolvedValue(null);
+
+    await getTopic({ userId: "user_7", courseId: "course_1", topicId: "topic_1" });
+
+    expect(dbMock.purchase.findUnique).toHaveBeenCalledWith({
+      where: { userId_courseId: { userId: "user_7", courseId: "course_1" } },
+    });
+  });
+
+  it("scopes progress to this learner and this Topic", async () => {
+    dbMock.purchase.findUnique.mockResolvedValue(null);
+
+    await getTopic({ userId: "user_7", courseId: "course_1", topicId: "topic_1" });
+
+    expect(dbMock.userProgress.findUnique).toHaveBeenCalledWith({
+      where: { userId_topicId: { userId: "user_7", topicId: "topic_1" } },
+    });
+  });
+});
+
+describe("an unpublished or missing Course", () => {
+  it("returns nothing when the Course is unpublished", async () => {
+    topicResolves();
+    dbMock.course.findUnique.mockResolvedValue(null);
+    dbMock.purchase.findUnique.mockResolvedValue({ id: "purchase_1" });
+
+    const result = await getTopic({
+      userId: "user_1",
+      courseId: "course_1",
+      topicId: "topic_1",
+    });
+
+    expect(result.topic).toBeNull();
+    expect(result.course).toBeNull();
+  });
+});

--- a/tests/unit/courses/topic-access.test.ts
+++ b/tests/unit/courses/topic-access.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { dbMock } from "../support/db";
+
+vi.mock("@/lib/db", async () => ({ db: (await import("../support/db")).dbMock }));
+
+const {
+  findPublishedTopicInCourse,
+  publishedTopicInCourse,
+  topicBelongsToCourse,
+  topicInCourse,
+} = await import("@/lib/courses/topic-access");
+
+/**
+ * The Course → Module → Topic relationship (#39).
+ *
+ * A Topic id in a URL proves nothing about which Course it belongs to. These
+ * tests assert the *shape of the query*, not just its result: a check that ran
+ * after an unfiltered read would satisfy a return-value test and still leave
+ * the row exposed to any call site that forgot to run it.
+ */
+describe("publishedTopicInCourse", () => {
+  it("binds the Topic to the Course through its Module", () => {
+    expect(publishedTopicInCourse("course_1", "topic_1")).toEqual({
+      id: "topic_1",
+      isPublished: true,
+      module: { courseId: "course_1", isPublished: true },
+    });
+  });
+
+  it("requires the Module to be published, not only the Topic", () => {
+    // Withdrawing a Module from learners has to actually withdraw its Topics.
+    // Filtering on the Topic alone would leave them reachable by direct URL.
+    const where = publishedTopicInCourse("course_1", "topic_1");
+
+    expect(where.isPublished).toBe(true);
+    expect(where.module.isPublished).toBe(true);
+  });
+
+  it("never omits the Course binding", () => {
+    const where = publishedTopicInCourse("course_1", "topic_1");
+
+    expect(where.module.courseId).toBe("course_1");
+  });
+});
+
+describe("topicInCourse", () => {
+  it("keeps the Course binding but not the publication filter", () => {
+    // Staff author unpublished content by definition. The Course binding is
+    // what must never be dropped.
+    expect(topicInCourse("course_1", "topic_1")).toEqual({
+      id: "topic_1",
+      module: { courseId: "course_1" },
+    });
+  });
+});
+
+describe("findPublishedTopicInCourse", () => {
+  beforeEach(() => {
+    dbMock.topic.findFirst.mockResolvedValue({
+      id: "topic_1",
+      moduleId: "module_1",
+      module: { id: "module_1", courseId: "course_1" },
+    });
+  });
+
+  it("queries with the full relationship asserted", async () => {
+    await findPublishedTopicInCourse("course_1", "topic_1");
+
+    expect(dbMock.topic.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: "topic_1",
+        isPublished: true,
+        module: { courseId: "course_1", isPublished: true },
+      },
+      include: { module: true },
+    });
+  });
+
+  it("returns null for a Topic that belongs to another Course", async () => {
+    // The filter means the row simply does not come back -- the caller cannot
+    // accidentally use it, because it never has it.
+    dbMock.topic.findFirst.mockResolvedValue(null);
+
+    await expect(findPublishedTopicInCourse("course_1", "topic_from_course_2"))
+      .resolves.toBeNull();
+  });
+
+  it("uses findFirst rather than findUnique, so the filter cannot be ignored", async () => {
+    // `findUnique` accepts only unique fields, which is what forced the original
+    // code to look the Topic up by id alone. The relationship needs findFirst.
+    await findPublishedTopicInCourse("course_1", "topic_1");
+
+    expect(dbMock.topic.findUnique).not.toHaveBeenCalled();
+    expect(dbMock.topic.findFirst).toHaveBeenCalled();
+  });
+});
+
+describe("topicBelongsToCourse", () => {
+  it("is true when the Topic is in the Course", async () => {
+    dbMock.topic.findFirst.mockResolvedValue({ id: "topic_1" });
+
+    await expect(topicBelongsToCourse("course_1", "topic_1")).resolves.toBe(true);
+  });
+
+  it("is false when it is not, without leaking the row", async () => {
+    dbMock.topic.findFirst.mockResolvedValue(null);
+
+    await expect(topicBelongsToCourse("course_1", "topic_9")).resolves.toBe(false);
+    expect(dbMock.topic.findFirst).toHaveBeenCalledWith({
+      where: { id: "topic_9", module: { courseId: "course_1" } },
+      select: { id: true },
+    });
+  });
+
+  it("does not filter on publication, so staff mutations still resolve", async () => {
+    dbMock.topic.findFirst.mockResolvedValue({ id: "topic_1" });
+
+    await topicBelongsToCourse("course_1", "topic_1");
+
+    const where = dbMock.topic.findFirst.mock.calls[0][0].where;
+    expect(where).not.toHaveProperty("isPublished");
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -68,6 +68,8 @@ export default defineConfig({
         // The Course -> Module -> Topic binding is the fix for #39; every branch
         // of it must be exercised.
         "lib/courses/topic-access.ts": { lines: 100, functions: 100, branches: 100, statements: 100 },
+        // Completion decides certificate issuance.
+        "lib/courses/completion.ts": { lines: 100, functions: 100, branches: 100, statements: 100 },
       },
     },
   },

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -48,6 +48,7 @@ export default defineConfig({
       include: [
         "lib/auth/*.ts",
         "lib/courses/*.ts",
+        "lib/assessments/*.ts",
         "lib/streak-service.ts",
         "lib/badge-service.ts",
         "lib/certificate-service.ts",
@@ -70,6 +71,8 @@ export default defineConfig({
         "lib/courses/topic-access.ts": { lines: 100, functions: 100, branches: 100, statements: 100 },
         // Completion decides certificate issuance.
         "lib/courses/completion.ts": { lines: 100, functions: 100, branches: 100, statements: 100 },
+        // Grading feeds certificates and analytics.
+        "lib/assessments/grading.ts": { lines: 100, functions: 100, branches: 100, statements: 100 },
       },
     },
   },

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -47,6 +47,7 @@ export default defineConfig({
       reportsDirectory: "coverage/unit",
       include: [
         "lib/auth/*.ts",
+        "lib/courses/*.ts",
         "lib/streak-service.ts",
         "lib/badge-service.ts",
         "lib/certificate-service.ts",
@@ -64,6 +65,9 @@ export default defineConfig({
         "lib/auth/policy.ts": { lines: 100, functions: 100, branches: 100, statements: 100 },
         "lib/auth/actions.ts": { lines: 100, functions: 100, branches: 100, statements: 100 },
         "lib/auth/errors.ts": { lines: 100, functions: 100, branches: 100, statements: 100 },
+        // The Course -> Module -> Topic binding is the fix for #39; every branch
+        // of it must be exercised.
+        "lib/courses/topic-access.ts": { lines: 100, functions: 100, branches: 100, statements: 100 },
       },
     },
   },


### PR DESCRIPTION
Closes #39, #40, #41, and makes ADR 0001 §1 structurally true.

Four commits, each independently reviewable. They're one PR because they overlap on the same handlers — the progress route is #39's binding *and* #40's integrity, and stacking PRs has bitten this branch twice already.

## #39 — cross-course Topic access

`getTopic` loaded the Topic by id alone, then gated content on a purchase of the Course named **in the URL**. Substituting another Course's Topic id into a purchased Course's URL returned that Topic — and since the entitlement check looked at the route's Course rather than the Topic's, it released the video and attachments too. **Owning one Course unlocked content in every other.**

The authoring routes had the same shape from the other direction: they confirmed Course ownership, then loaded the Topic by id, so an owner of any Course could edit, publish, or delete a Topic in another.

The relationship now lives in `lib/courses/topic-access.ts` as a `where` fragment, so it can't be forgotten at a call site or be true-but-unused. Publication is part of it — an unpublished Module must not expose its Topics, or withdrawing a Module wouldn't withdraw anything.

## #40 — arbitrary progress and vacuous completion

The progress endpoint accepted **any Topic id from any authenticated learner**, with no entitlement check and no body validation. That matters because the handler awards badges, advances streaks, marks the Enrollment `COMPLETED`, and **issues a certificate**. A learner who had bought nothing could complete anything.

It also completed *nothing*. Both checks were a bare `.every()`, and `[].every()` is `true` — so a Course with no published Topics reported complete and issued a certificate for finishing nothing. Rules now live in `lib/courses/completion.ts` as pure functions requiring at least one published Topic.

## #41 — quiz submission binding

The submit route checked the attempt belonged to the caller, then graded against the questions of the Quiz **named in the route**. Those differ whenever the caller says so: an attempt started on one Quiz could be submitted through another Quiz's URL and scored against questions it was never issued.

Answers were entirely unvalidated — nothing checked a `questionId` belonged to the Quiz, a `selectedOptionId` to that Question, or that a Question was answered once. Foreign-but-real ids satisfy the foreign keys, so they were written and graded without complaint.

Answers and finalisation now commit in one transaction, with finalisation a conditional update on `completedAt` still being null, so concurrent submissions can't both claim the attempt.

**A separate bug surfaced while extracting the grader.** Correctness was `userAnswer?.selectedOptionId === correctOption?.id` — `undefined === undefined`, i.e. **true** — for an unanswered Question on a Quiz where no option is marked correct. It awarded full points for answering nothing.

## The follow-up: one derivation point, enforced

42 files still read the Clerk session directly. No role logic, so nothing exploitable — but the invariant held only while everyone remembered it, and new code copies what it finds nearby. All 42 now derive the principal from `lib/auth`.

Five routes still resolved Course ownership by hand; they now call `authorizeCourse`/`authorizeTopicInCourse`. **No hand-rolled ownership check remains in `app/api`.** `checkout` derived the payer from `currentUser().id` — a second identity path on a money route — and now takes the id from the principal.

An **ESLint rule** keeps it true: importing `auth` from `@clerk/nextjs/server` outside `lib/auth`/`proxy.ts` fails the build. Verified it fires on a new file and stays off inside `lib/auth`. Without it the sweep decays the first time someone copies an older handler.

## Evidence

Every fix has a regression that fails against the original code.

| Module | Mutants | Killed |
| --- | --- | --- |
| `lib/courses/completion.ts` | 5 (incl. removing each emptiness guard) | 5 |
| `lib/assessments/grading.ts` | 5 (incl. restoring the `undefined===undefined` bug) | 5 |

For #39 the regression models a Topic that **genuinely exists in another Course** — `findUnique` returns it, `findFirst` honours the binding — so restoring the original query fails seven tests. An earlier draft returned null for both lookups and passed against the broken code; that would have been worthless, and it's the third fixture-passing-for-the-wrong-reason this work has surfaced.

```
npm run validate       # exit 0
npm run build

Test Files  13 passed (13)
     Tests  373 passed (373)

Statements : 99.05%   Branches : 96.62%
Functions  : 100%     Lines    : 100%
```

## Rollout

Behaviour changes are all denials of things that shouldn't have worked. Learners on their own Courses are unaffected; a learner relying on cross-course access was exploiting a bug. No migration, no schema change. Rollback is a revert.

Not included: `#48` (Enrollment as canonical entitlement — progress still reads `Purchase`), `#49`/`#63` (transactional completion and the attempt state machine), `#59` (fuller completion rules), `#65` (publication invariants). Each is referenced from the code it will replace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RH1AUJJFKCXc2SuRcML9vg
