### PR TITLE
test: add an isolated PostgreSQL integration harness (#107)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,55 @@ jobs:
           path: coverage/unit
           retention-days: 7
 
+  integration:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+
+    # A real PostgreSQL, because the behaviour this job exists to prove -- row
+    # level security, constraints, cascades, transaction and concurrency
+    # semantics -- is invisible to a test double by construction (ADR 0003).
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      # The suite applies the committed migrations to a template database and
+      # clones it per worker, so a migration that does not apply cleanly fails
+      # here rather than in production.
+      - name: Run integration tests
+        run: npm run test:integration
+        env:
+          TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
+
+      - name: Report migration state on failure
+        if: failure()
+        env:
+          PGPASSWORD: postgres
+        run: |
+          psql -h localhost -U postgres -d akomapa_integration_template \
+            -c 'SELECT migration_name, finished_at FROM _prisma_migrations ORDER BY started_at' \
+            || echo "template database unavailable"
+
   evals:
     name: AI Evaluation Dataset
     runs-on: ubuntu-latest

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -10,12 +10,14 @@ one is how suites become slow and flaky.
 | Suite | Command | What belongs in it | Owner |
 | --- | --- | --- | --- |
 | Unit | `npm run test:unit` | Pure domain logic: entitlement, RBAC, completion, grading, badges, streaks, certificate eligibility, AI usage accounting | [#106](https://github.com/akomapahealth/akomapa-lms/issues/106) |
-| Integration | not yet available | Route handlers, RLS policies, transactions, migrations, Stripe and Clerk webhooks, against isolated PostgreSQL | [#107](https://github.com/akomapahealth/akomapa-lms/issues/107) |
+| Integration | `npm run test:integration` | Route handlers, RLS policies, transactions, migrations, constraints, concurrency, webhooks — against real PostgreSQL | [#107](https://github.com/akomapahealth/akomapa-lms/issues/107) |
 | Browser | `npm run test:e2e` | Authenticated learner, faculty, admin, commerce, and AI journeys | [#108](https://github.com/akomapahealth/akomapa-lms/issues/108) |
 | Document | `npm run test:checks`, `npm run test:evals` | Source-of-truth documents and the AI evaluation dataset | [#37](https://github.com/akomapahealth/akomapa-lms/issues/37), [#79](https://github.com/akomapahealth/akomapa-lms/issues/79) |
 
 `npm run validate` runs lint, typecheck, and every suite that does not need a
-database or a browser. Run it before opening a pull request.
+database or a browser. Run it before opening a pull request. The integration
+suite is deliberately excluded — it needs PostgreSQL, and `validate` must stay
+runnable anywhere.
 
 ## The unit suite
 
@@ -83,6 +85,54 @@ awarded, that a certificate is not issued. Coverage percentages prove a line
 ran, not that anything was checked — for the highest-risk invariants, corrupt
 the dependency and assert the deny-by-default contract still holds, as
 `tests/unit/roles.test.ts` does at the persistence boundary.
+
+## The integration suite
+
+```
+npm run test:integration
+npm run test:integration:watch
+```
+
+It needs a PostgreSQL server it may create and drop databases on. Point it at
+one with `TEST_DATABASE_URL`, or let it fall back to `DATABASE_URL`:
+
+```
+TEST_DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres \
+  npm run test:integration
+```
+
+An exported value wins over the dotenv files, so aiming a run at a throwaway
+server is one shell prefix.
+
+### It builds from the committed migrations
+
+Global setup drops and recreates a template database, then applies
+`prisma/migrations` to it with `prisma migrate deploy` — not a schema push. A
+migration that does not apply cleanly fails the build here rather than in
+production. `tests/integration/harness.test.ts` asserts this, so the suite
+cannot quietly start running against an unmigrated database.
+
+### Each worker owns a database
+
+Every worker clones the template with `CREATE DATABASE ... TEMPLATE`, which is a
+file copy, so adding workers costs almost nothing and no two workers can see
+each other's rows. Tables are truncated between tests; every test creates the
+rows it needs.
+
+Databases are named `akomapa_integration_*` and dropped in teardown, including
+any left behind by a killed run.
+
+### What belongs here rather than in the unit suite
+
+Anything a test double cannot observe: a relation name being wrong, a nested
+filter traversing a different relation than it reads like, a unique constraint,
+a cascade, transaction rollback, two concurrent writes racing, and — from #43 —
+row-level security policies. A mock will happily accept two conflicting writes
+and honour no constraint at all.
+
+Route handlers are exercised for real. Only the Clerk session is mocked; the
+principal lookup, authorization, writes, and cascades all run against
+PostgreSQL.
 
 ### Characterisation tests
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "test:unit": "vitest run",
     "test:unit:watch": "vitest",
     "test:unit:coverage": "vitest run --coverage",
+    "test:integration": "vitest run --config vitest.integration.config.mts",
+    "test:integration:watch": "vitest --config vitest.integration.config.mts",
     "validate": "npm run lint && npm run typecheck && npm run test:unit && npm run test:evals && npm run test:checks",
     "postinstall": "prisma generate",
     "db:migrate": "prisma migrate dev",

--- a/tests/integration/authorization.test.ts
+++ b/tests/integration/authorization.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { testDb } from "./support/db";
+import { aCourseWithTopic, aPurchaseRow, aUserRow } from "./support/fixtures";
+
+// The guards import `@/lib/db`. Point that at the disposable database, lazily,
+// so the module graph does not need the real connection string at import time.
+vi.mock("@/lib/db", async () => {
+  const { testDb: get } = await import("./support/db");
+  return {
+    get db() {
+      return get();
+    },
+  };
+});
+
+const { authorizeCourse, authorizeTopicInCourse } = await import("@/lib/auth/guards");
+const { Denied } = await import("@/lib/auth/errors");
+const { findPublishedTopicInCourse } = await import("@/lib/courses/topic-access");
+const { getTopic } = await import("@/actions/get-topic");
+
+/**
+ * The Wave 1 authorization fixes, against real rows.
+ *
+ * The unit suite asserts the *shape* of each query. These assert what
+ * PostgreSQL actually returns for it — which is the only way to know that a
+ * relation name is right, that a nested filter traverses the relation the way
+ * it reads, and that the row genuinely does not come back.
+ */
+async function reasonFor(promise: Promise<unknown>): Promise<string> {
+  try {
+    await promise;
+    throw new Error("expected the guard to deny");
+  } catch (error) {
+    if (error instanceof Denied) return error.reason;
+    throw error;
+  }
+}
+
+describe("cross-course Topic access (#39)", () => {
+  let learner: { id: string };
+  let owned: Awaited<ReturnType<typeof aCourseWithTopic>>;
+  let foreign: Awaited<ReturnType<typeof aCourseWithTopic>>;
+
+  beforeEach(async () => {
+    learner = await aUserRow();
+    const author = await aUserRow({ role: "FACULTY" });
+
+    owned = await aCourseWithTopic(author.id);
+    foreign = await aCourseWithTopic(author.id);
+
+    // The learner legitimately owns the first Course and nothing else.
+    await aPurchaseRow(learner.id, owned.course.id);
+  });
+
+  it("finds a Topic through its own Course", async () => {
+    const found = await findPublishedTopicInCourse(owned.course.id, owned.topic.id);
+
+    expect(found?.id).toBe(owned.topic.id);
+  });
+
+  it("does not find a Topic through a different Course", async () => {
+    // Both rows exist. Only the relationship differs, which is exactly what a
+    // mock cannot verify.
+    const found = await findPublishedTopicInCourse(owned.course.id, foreign.topic.id);
+
+    expect(found).toBeNull();
+  });
+
+  it("returns no content for a foreign Topic even to a paying learner", async () => {
+    const result = await getTopic({
+      userId: learner.id,
+      courseId: owned.course.id,
+      topicId: foreign.topic.id,
+    });
+
+    expect(result.topic).toBeNull();
+    expect(result.muxData).toBeNull();
+    expect(result.attachments).toEqual([]);
+  });
+
+  it("still serves the Topic the learner actually bought", async () => {
+    const result = await getTopic({
+      userId: learner.id,
+      courseId: owned.course.id,
+      topicId: owned.topic.id,
+    });
+
+    expect(result.topic?.id).toBe(owned.topic.id);
+    expect(result.purchase).not.toBeNull();
+  });
+
+  it("hides a Topic whose Module is unpublished, even inside the right Course", async () => {
+    await testDb().module.update({
+      where: { id: owned.module.id },
+      data: { isPublished: false },
+    });
+
+    const found = await findPublishedTopicInCourse(owned.course.id, owned.topic.id);
+
+    expect(found).toBeNull();
+  });
+});
+
+describe("authoring ownership (#42, #39)", () => {
+  it("lets an author reach their own Course and Topic", async () => {
+    const author = await aUserRow({ role: "FACULTY" });
+    const { course, topic } = await aCourseWithTopic(author.id);
+    const principal = { userId: author.id, role: "FACULTY" as const };
+
+    await expect(authorizeCourse(principal, "course:update", course.id)).resolves.toMatchObject({
+      id: course.id,
+    });
+    await expect(
+      authorizeTopicInCourse(principal, "topic:update", course.id, topic.id)
+    ).resolves.toMatchObject({ id: topic.id });
+  });
+
+  it("denies an author another author's Course", async () => {
+    const author = await aUserRow({ role: "FACULTY" });
+    const stranger = await aUserRow({ role: "FACULTY" });
+    const { course } = await aCourseWithTopic(author.id);
+
+    expect(
+      await reasonFor(
+        authorizeCourse({ userId: stranger.id, role: "FACULTY" }, "course:delete", course.id)
+      )
+    ).toBe("not_found");
+  });
+
+  it("denies a Topic from another Course even to that Course's owner", async () => {
+    const author = await aUserRow({ role: "FACULTY" });
+    const owned = await aCourseWithTopic(author.id);
+    const other = await aCourseWithTopic(author.id);
+
+    // Same author owns both, so this is purely the Course→Module→Topic binding.
+    expect(
+      await reasonFor(
+        authorizeTopicInCourse(
+          { userId: author.id, role: "FACULTY" },
+          "topic:delete",
+          owned.course.id,
+          other.topic.id
+        )
+      )
+    ).toBe("not_found");
+  });
+
+  it("denies a learner before any row is read", async () => {
+    const learner = await aUserRow();
+    const author = await aUserRow({ role: "FACULTY" });
+    const { course } = await aCourseWithTopic(author.id);
+
+    expect(
+      await reasonFor(
+        authorizeCourse({ userId: learner.id, role: "STUDENT" }, "course:update", course.id)
+      )
+    ).toBe("forbidden");
+  });
+});

--- a/tests/integration/harness.test.ts
+++ b/tests/integration/harness.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { testDb } from "./support/db";
+
+/**
+ * Proves the harness itself before anything relies on it.
+ *
+ * A test suite that silently runs against an unmigrated or shared database
+ * produces confident, meaningless results, so these assertions come first.
+ */
+describe("the integration database", () => {
+  it("is built from the committed migrations, not a schema push", async () => {
+    const applied = await testDb().$queryRaw<{ migration_name: string }[]>`
+      SELECT migration_name FROM _prisma_migrations WHERE finished_at IS NOT NULL
+    `;
+
+    // Every directory under prisma/migrations must have been applied. A schema
+    // pushed from schema.prisma would leave this table empty while still
+    // producing tables that look correct.
+    expect(applied.length).toBeGreaterThanOrEqual(6);
+    expect(applied.map((row) => row.migration_name)).toContain(
+      "20260609000000_phase1_modules_quizzes_roles"
+    );
+  });
+
+  it("has no pending migrations", async () => {
+    const pending = await testDb().$queryRaw<{ count: bigint }[]>`
+      SELECT count(*)::bigint AS count FROM _prisma_migrations WHERE finished_at IS NULL
+    `;
+
+    expect(Number(pending[0].count)).toBe(0);
+  });
+
+  it("is a disposable database, never the developer's own", async () => {
+    const [{ current_database }] = await testDb().$queryRaw<
+      { current_database: string }[]
+    >`SELECT current_database()`;
+
+    expect(current_database).toMatch(/^akomapa_integration_w/);
+  });
+
+  it("starts every test empty", async () => {
+    // The truncate in afterEach is what makes tests independent; if it stopped
+    // working, tests would pass or fail depending on their order.
+    expect(await testDb().user.count()).toBe(0);
+    expect(await testDb().course.count()).toBe(0);
+  });
+
+  it("persists rows within a test", async () => {
+    await testDb().user.create({ data: { id: "user_1", email: "a@example.test" } });
+
+    expect(await testDb().user.count()).toBe(1);
+  });
+
+  it("does not carry rows into the next test", async () => {
+    // Deliberately paired with the test above: this one fails if truncation
+    // regresses, and it is ordered after it.
+    expect(await testDb().user.count()).toBe(0);
+  });
+});

--- a/tests/integration/progress-route.test.ts
+++ b/tests/integration/progress-route.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { testDb } from "./support/db";
+import { aCourseWithTopic, aPurchaseRow, aUserRow } from "./support/fixtures";
+
+const clerkAuth = vi.hoisted(() => vi.fn());
+vi.mock("@clerk/nextjs/server", () => ({ auth: clerkAuth }));
+vi.mock("@/lib/db", async () => {
+  const { testDb: get } = await import("./support/db");
+  return {
+    get db() {
+      return get();
+    },
+  };
+});
+
+const { PUT } = await import(
+  "@/app/api/courses/[courseId]/chapters/[chapterId]/progress/route"
+);
+
+/**
+ * A real route handler, against a real database.
+ *
+ * Everything the handler touches is genuine except the Clerk session: the
+ * principal lookup, the Topic binding, the entitlement check, the progress
+ * write, and the completion cascade all run against PostgreSQL. This is the
+ * layer where #40's fixes are actually provable.
+ */
+function request(isCompleted: unknown) {
+  return new Request("http://localhost/progress", {
+    method: "PUT",
+    body: JSON.stringify({ isCompleted }),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const params = (courseId: string, chapterId: string) =>
+  Promise.resolve({ courseId, chapterId });
+
+describe("PUT progress", () => {
+  let learner: { id: string };
+  let owned: Awaited<ReturnType<typeof aCourseWithTopic>>;
+  let foreign: Awaited<ReturnType<typeof aCourseWithTopic>>;
+
+  beforeEach(async () => {
+    learner = await aUserRow();
+    const author = await aUserRow({ role: "FACULTY" });
+    owned = await aCourseWithTopic(author.id);
+    foreign = await aCourseWithTopic(author.id);
+    clerkAuth.mockResolvedValue({ userId: learner.id });
+  });
+
+  it("records completion for a Topic the learner has bought", async () => {
+    await aPurchaseRow(learner.id, owned.course.id);
+
+    const response = await PUT(request(true), {
+      params: params(owned.course.id, owned.topic.id),
+    });
+
+    expect(response.status).toBe(200);
+    const progress = await testDb().userProgress.findUnique({
+      where: { userId_topicId: { userId: learner.id, topicId: owned.topic.id } },
+    });
+    expect(progress?.isCompleted).toBe(true);
+  });
+
+  it("refuses a Topic belonging to a different Course", async () => {
+    await aPurchaseRow(learner.id, owned.course.id);
+
+    const response = await PUT(request(true), {
+      params: params(owned.course.id, foreign.topic.id),
+    });
+
+    expect(response.status).toBe(404);
+    expect(await testDb().userProgress.count()).toBe(0);
+  });
+
+  it("refuses a learner who has not bought the Course", async () => {
+    // Before #40 this wrote progress, awarded badges, and could issue a
+    // certificate for a Course the learner had never paid for.
+    const response = await PUT(request(true), {
+      params: params(owned.course.id, owned.topic.id),
+    });
+
+    expect(response.status).toBe(404);
+    expect(await testDb().userProgress.count()).toBe(0);
+  });
+
+  it("allows a free-preview Topic without a purchase", async () => {
+    const free = await aCourseWithTopic(learner.id, { topicIsFree: true });
+
+    const response = await PUT(request(true), {
+      params: params(free.course.id, free.topic.id),
+    });
+
+    expect(response.status).toBe(200);
+  });
+
+  it("refuses an unauthenticated request", async () => {
+    clerkAuth.mockResolvedValue({ userId: null });
+    await aPurchaseRow(learner.id, owned.course.id);
+
+    const response = await PUT(request(true), {
+      params: params(owned.course.id, owned.topic.id),
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects a non-boolean isCompleted", async () => {
+    await aPurchaseRow(learner.id, owned.course.id);
+
+    for (const value of ["true", 1, {}, null]) {
+      const response = await PUT(request(value), {
+        params: params(owned.course.id, owned.topic.id),
+      });
+      expect(response.status).toBe(400);
+    }
+
+    expect(await testDb().userProgress.count()).toBe(0);
+  });
+
+  it("issues no certificate for a Course whose only Topic is unpublished", async () => {
+    // The vacuous-completion case. The Course has no published Topics, so
+    // completing anything must not finish it.
+    const empty = await aCourseWithTopic(learner.id, { topicIsFree: true });
+    await testDb().topic.update({
+      where: { id: empty.topic.id },
+      data: { isPublished: false },
+    });
+
+    const response = await PUT(request(true), {
+      params: params(empty.course.id, empty.topic.id),
+    });
+
+    // The Topic is no longer learner-visible, so the write is refused outright.
+    expect(response.status).toBe(404);
+    expect(await testDb().certificate.count()).toBe(0);
+    expect(await testDb().enrollment.count()).toBe(0);
+  });
+
+  it("completes the Course and issues one certificate when every Topic is done", async () => {
+    const author = await aUserRow({ role: "FACULTY" });
+    const single = await aCourseWithTopic(author.id, { topicIsFree: true });
+    await testDb().enrollment.create({
+      data: { userId: learner.id, courseId: single.course.id },
+    });
+
+    const response = await PUT(request(true), {
+      params: params(single.course.id, single.topic.id),
+    });
+
+    expect(response.status).toBe(200);
+
+    const enrollment = await testDb().enrollment.findFirst({
+      where: { userId: learner.id, courseId: single.course.id },
+    });
+    expect(enrollment?.status).toBe("COMPLETED");
+    expect(await testDb().certificate.count()).toBe(1);
+  });
+
+  it("issues exactly one certificate when completion is replayed", async () => {
+    const author = await aUserRow({ role: "FACULTY" });
+    const single = await aCourseWithTopic(author.id, { topicIsFree: true });
+    await testDb().enrollment.create({
+      data: { userId: learner.id, courseId: single.course.id },
+    });
+
+    await PUT(request(true), { params: params(single.course.id, single.topic.id) });
+    await PUT(request(true), { params: params(single.course.id, single.topic.id) });
+
+    // The unique constraint on (userId, courseId) plus the service's own
+    // existing-certificate check make re-completion idempotent.
+    expect(await testDb().certificate.count()).toBe(1);
+  });
+});

--- a/tests/integration/support/database-url.ts
+++ b/tests/integration/support/database-url.ts
@@ -1,0 +1,52 @@
+/**
+ * Where the integration suite gets its database, and how it names the
+ * disposable ones it creates.
+ *
+ * Kept free of imports so it can be used from Vitest's global setup, from a
+ * worker's setup file, and from a plain script without dragging the Prisma
+ * client into any of them.
+ */
+
+/** The server the suite is allowed to create and drop databases on. */
+export function adminConnectionString(): string {
+  const url = process.env.TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+
+  if (!url) {
+    throw new Error(
+      "Neither TEST_DATABASE_URL nor DATABASE_URL is set. The integration " +
+        "suite needs a PostgreSQL server it may create and drop databases on. " +
+        "See docs/agents/testing.md."
+    );
+  }
+
+  return url;
+}
+
+/**
+ * The template database: migrated once, then cloned per worker.
+ *
+ * Applying every migration once per worker is the slow part of an integration
+ * suite. `CREATE DATABASE ... TEMPLATE` copies an already-migrated database at
+ * file-copy speed, so adding workers costs almost nothing.
+ */
+export const TEMPLATE_DATABASE = "akomapa_integration_template";
+
+/** One disposable database per Vitest worker, so workers cannot see each other. */
+export function workerDatabase(workerId: string): string {
+  // Worker ids come from Vitest and are numeric, but this string is
+  // interpolated into DDL, so it is constrained rather than trusted.
+  const safe = workerId.replace(/[^0-9a-z_]/gi, "").slice(0, 16) || "0";
+  return `akomapa_integration_w${safe}`;
+}
+
+/** Rewrites a connection string to point at a different database on the same server. */
+export function withDatabase(connectionString: string, database: string): string {
+  const url = new URL(connectionString);
+  url.pathname = `/${database}`;
+  return url.toString();
+}
+
+/** The database a connection string points at. */
+export function databaseOf(connectionString: string): string {
+  return new URL(connectionString).pathname.replace(/^\//, "");
+}

--- a/tests/integration/support/db.ts
+++ b/tests/integration/support/db.ts
@@ -1,0 +1,67 @@
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@prisma/client";
+import { Pool } from "pg";
+
+/**
+ * The Prisma client the integration suite talks to.
+ *
+ * A real client against a real database, built the same way `lib/db.ts` builds
+ * the production one -- a `pg` pool behind the Prisma driver adapter -- so the
+ * suite exercises the same stack, including anything that behaves differently
+ * under pooling. That matters for #43, where the whole point is that a pooled
+ * connection must not carry a principal between requests.
+ */
+let pool: Pool | undefined;
+let client: PrismaClient | undefined;
+
+export async function connectTestDatabase(connectionString: string) {
+  pool = new Pool({ connectionString });
+  client = new PrismaClient({ adapter: new PrismaPg(pool) });
+  await client.$queryRaw`SELECT 1`;
+}
+
+export function testDb(): PrismaClient {
+  if (!client) {
+    throw new Error(
+      "The test database is not connected. Integration tests must run under " +
+        "vitest.integration.config.mts, which installs the setup file."
+    );
+  }
+  return client;
+}
+
+/** The raw pool, for statements Prisma cannot express. */
+export function testPool(): Pool {
+  if (!pool) throw new Error("The test database is not connected.");
+  return pool;
+}
+
+/**
+ * Empties every table between tests.
+ *
+ * Discovered from the catalogue rather than listed by hand, so a new model
+ * cannot quietly start leaking rows between tests. `_prisma_migrations` is
+ * preserved: dropping it would make the database look unmigrated.
+ */
+export async function truncateAll() {
+  const rows = await testDb().$queryRaw<{ tablename: string }[]>`
+    SELECT tablename
+      FROM pg_tables
+     WHERE schemaname = 'public'
+       AND tablename <> '_prisma_migrations'
+  `;
+
+  if (rows.length === 0) return;
+
+  const tables = rows.map((row) => `"public"."${row.tablename}"`).join(", ");
+  await testDb().$executeRawUnsafe(
+    `TRUNCATE TABLE ${tables} RESTART IDENTITY CASCADE`
+  );
+}
+
+export async function closeTestDatabase() {
+  await client?.$disconnect();
+  await pool?.end();
+  client = undefined;
+  pool = undefined;
+}

--- a/tests/integration/support/fixtures.ts
+++ b/tests/integration/support/fixtures.ts
@@ -1,0 +1,93 @@
+import { testDb } from "./db";
+
+/**
+ * Real rows, in a real database.
+ *
+ * The unit suite's builders describe shapes; these create actual rows so that
+ * foreign keys, unique constraints, cascades, and (from #43) row-level security
+ * policies all apply. A fixture that a constraint rejects is itself a finding.
+ */
+let sequence = 0;
+const unique = (prefix: string) => `${prefix}_${++sequence}`;
+
+export async function aUserRow(overrides: { id?: string; role?: string } = {}) {
+  const id = overrides.id ?? unique("user");
+  return testDb().user.create({
+    data: { id, email: `${id}@example.test`, role: overrides.role ?? "STUDENT" },
+  });
+}
+
+/** A published Course with one published Module and one published Topic. */
+export async function aCourseWithTopic(
+  ownerId: string,
+  overrides: { isPublished?: boolean; topicIsFree?: boolean; topicPublished?: boolean } = {}
+) {
+  const course = await testDb().course.create({
+    data: {
+      id: unique("course"),
+      userId: ownerId,
+      title: "Research Ethics",
+      isPublished: overrides.isPublished ?? true,
+    },
+  });
+
+  const courseModule = await testDb().module.create({
+    data: {
+      id: unique("module"),
+      courseId: course.id,
+      title: "Foundations",
+      position: 1,
+      isPublished: true,
+    },
+  });
+
+  const topic = await testDb().topic.create({
+    data: {
+      id: unique("topic"),
+      moduleId: courseModule.id,
+      title: "Consent",
+      position: 1,
+      isPublished: overrides.topicPublished ?? true,
+      isFree: overrides.topicIsFree ?? false,
+    },
+  });
+
+  return { course, module: courseModule, topic };
+}
+
+export async function aPurchaseRow(userId: string, courseId: string) {
+  return testDb().purchase.create({ data: { userId, courseId } });
+}
+
+/** A published Quiz with one question and two options, one of them correct. */
+export async function aQuizWithQuestion(courseId: string) {
+  const quiz = await testDb().quiz.create({
+    data: {
+      id: unique("quiz"),
+      courseId,
+      title: "Module check",
+      type: "MODULE_QUIZ",
+      isPublished: true,
+      passingScore: 70,
+    },
+  });
+
+  const question = await testDb().question.create({
+    data: { id: unique("question"), quizId: quiz.id, text: "Which?", position: 1, points: 10 },
+  });
+
+  const [correct, wrong] = await Promise.all([
+    testDb().questionOption.create({
+      data: { id: unique("option"), questionId: question.id, text: "Right", isCorrect: true, position: 1 },
+    }),
+    testDb().questionOption.create({
+      data: { id: unique("option"), questionId: question.id, text: "Wrong", isCorrect: false, position: 2 },
+    }),
+  ]);
+
+  return { quiz, question, correct, wrong };
+}
+
+export async function anAttemptRow(userId: string, quizId: string) {
+  return testDb().quizAttempt.create({ data: { userId, quizId } });
+}

--- a/tests/integration/support/global-setup.ts
+++ b/tests/integration/support/global-setup.ts
@@ -1,0 +1,90 @@
+import { execFileSync } from "node:child_process";
+
+import { Client } from "pg";
+
+import {
+  adminConnectionString,
+  databaseOf,
+  TEMPLATE_DATABASE,
+  withDatabase,
+} from "./database-url";
+
+/**
+ * Builds the template database once per run.
+ *
+ * Every migration is applied here and nowhere else; workers clone this. That
+ * keeps a run's cost independent of the number of workers, and it means the
+ * suite exercises the *committed migrations* rather than a schema pushed from
+ * `schema.prisma` -- so a migration that does not apply cleanly fails the build
+ * rather than being silently bypassed.
+ */
+async function connectToMaintenanceDatabase(): Promise<Client> {
+  const admin = adminConnectionString();
+
+  // Never connect to the maintenance database we are about to drop.
+  const maintenance =
+    databaseOf(admin) === TEMPLATE_DATABASE
+      ? withDatabase(admin, "postgres")
+      : admin;
+
+  const client = new Client({ connectionString: maintenance });
+  await client.connect();
+  return client;
+}
+
+/** Ends every other session on a database, so it can be dropped or cloned. */
+async function disconnectOthers(client: Client, database: string) {
+  await client.query(
+    `SELECT pg_terminate_backend(pid)
+       FROM pg_stat_activity
+      WHERE datname = $1 AND pid <> pg_backend_pid()`,
+    [database]
+  );
+}
+
+export async function setup() {
+  const admin = adminConnectionString();
+  const client = await connectToMaintenanceDatabase();
+
+  try {
+    await disconnectOthers(client, TEMPLATE_DATABASE);
+    // Identifiers cannot be parameterised; TEMPLATE_DATABASE is a constant.
+    await client.query(`DROP DATABASE IF EXISTS "${TEMPLATE_DATABASE}"`);
+    await client.query(`CREATE DATABASE "${TEMPLATE_DATABASE}"`);
+  } finally {
+    await client.end();
+  }
+
+  const templateUrl = withDatabase(admin, TEMPLATE_DATABASE);
+
+  execFileSync("npx", ["prisma", "migrate", "deploy"], {
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      // prisma.config.ts prefers DIRECT_URL, so both are pinned at the
+      // template to stop a stray environment variable redirecting migrations
+      // at a real database.
+      DATABASE_URL: templateUrl,
+      DIRECT_URL: templateUrl,
+    },
+  });
+}
+
+export async function teardown() {
+  const client = await connectToMaintenanceDatabase();
+
+  try {
+    // Drop every database this suite created, including workers whose own
+    // teardown did not run because the process was killed.
+    const { rows } = await client.query<{ datname: string }>(
+      `SELECT datname FROM pg_database WHERE datname LIKE 'akomapa_integration_%'`
+    );
+
+    for (const { datname } of rows) {
+      await disconnectOthers(client, datname);
+      await client.query(`DROP DATABASE IF EXISTS "${datname}"`);
+    }
+  } finally {
+    await client.end();
+  }
+}

--- a/tests/integration/support/setup.ts
+++ b/tests/integration/support/setup.ts
@@ -1,0 +1,54 @@
+import { afterAll, afterEach, beforeAll } from "vitest";
+
+import {
+  adminConnectionString,
+  TEMPLATE_DATABASE,
+  withDatabase,
+  workerDatabase,
+} from "./database-url";
+import { closeTestDatabase, connectTestDatabase, truncateAll } from "./db";
+
+/**
+ * One disposable database per worker, cloned from the migrated template.
+ *
+ * Workers therefore cannot see each other's rows, which is what lets these
+ * tests use real tables without coordinating on ids. The clone is a file copy,
+ * so the cost of a worker is close to nothing.
+ */
+const workerId = process.env.VITEST_WORKER_ID ?? "0";
+const database = workerDatabase(workerId);
+
+beforeAll(async () => {
+  const admin = adminConnectionString();
+  const { Client } = await import("pg");
+
+  const maintenance = new Client({ connectionString: withDatabase(admin, "postgres") });
+  await maintenance.connect();
+
+  try {
+    await maintenance.query(
+      `SELECT pg_terminate_backend(pid)
+         FROM pg_stat_activity
+        WHERE datname = $1 AND pid <> pg_backend_pid()`,
+      [database]
+    );
+    await maintenance.query(`DROP DATABASE IF EXISTS "${database}"`);
+    await maintenance.query(
+      `CREATE DATABASE "${database}" TEMPLATE "${TEMPLATE_DATABASE}"`
+    );
+  } finally {
+    await maintenance.end();
+  }
+
+  await connectTestDatabase(withDatabase(admin, database));
+}, 60_000);
+
+afterEach(async () => {
+  // Truncate rather than re-clone: it is far faster, and every test declares
+  // the rows it needs, so leftover state from a neighbour is a bug either way.
+  await truncateAll();
+});
+
+afterAll(async () => {
+  await closeTestDatabase();
+});

--- a/tests/integration/transactions.test.ts
+++ b/tests/integration/transactions.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+
+import { testDb } from "./support/db";
+import {
+  aCourseWithTopic,
+  anAttemptRow,
+  aPurchaseRow,
+  aQuizWithQuestion,
+  aUserRow,
+} from "./support/fixtures";
+
+/**
+ * Transactions, concurrency, and constraints.
+ *
+ * None of this is observable against a mock: a test double will happily accept
+ * two conflicting writes, honour no unique constraint, and cascade nothing.
+ */
+describe("quiz submission is claimed exactly once (#41)", () => {
+  it("lets only one of two concurrent finalisations win", async () => {
+    const learner = await aUserRow();
+    const author = await aUserRow({ role: "FACULTY" });
+    const { course } = await aCourseWithTopic(author.id);
+    const { quiz } = await aQuizWithQuestion(course.id);
+    const attempt = await anAttemptRow(learner.id, quiz.id);
+
+    // The route's finalisation: a conditional update on completedAt still being
+    // null. Both callers pass the earlier `if (attempt.completedAt)` check, so
+    // this is the only thing standing between a double-click and two gradings.
+    const claim = () =>
+      testDb().quizAttempt.updateMany({
+        where: { id: attempt.id, completedAt: null },
+        data: { score: 10, totalPoints: 10, completedAt: new Date() },
+      });
+
+    const [first, second] = await Promise.all([claim(), claim()]);
+
+    expect(first.count + second.count).toBe(1);
+  });
+
+  it("leaves the attempt finalised exactly once", async () => {
+    const learner = await aUserRow();
+    const author = await aUserRow({ role: "FACULTY" });
+    const { course } = await aCourseWithTopic(author.id);
+    const { quiz } = await aQuizWithQuestion(course.id);
+    const attempt = await anAttemptRow(learner.id, quiz.id);
+
+    await testDb().quizAttempt.updateMany({
+      where: { id: attempt.id, completedAt: null },
+      data: { score: 10, totalPoints: 10, completedAt: new Date() },
+    });
+    const second = await testDb().quizAttempt.updateMany({
+      where: { id: attempt.id, completedAt: null },
+      data: { score: 0, totalPoints: 10, completedAt: new Date() },
+    });
+
+    expect(second.count).toBe(0);
+
+    // The second submission must not have overwritten the first score.
+    const finalised = await testDb().quizAttempt.findUnique({ where: { id: attempt.id } });
+    expect(finalised?.score).toBe(10);
+  });
+});
+
+describe("transaction rollback", () => {
+  it("discards every write when the transaction throws", async () => {
+    const learner = await aUserRow();
+    const author = await aUserRow({ role: "FACULTY" });
+    const { course } = await aCourseWithTopic(author.id);
+
+    await expect(
+      testDb().$transaction(async (tx) => {
+        await tx.purchase.create({ data: { userId: learner.id, courseId: course.id } });
+        await tx.enrollment.create({ data: { userId: learner.id, courseId: course.id } });
+        throw new Error("something failed after the writes");
+      })
+    ).rejects.toThrow("something failed after the writes");
+
+    // Neither row survives. A mock would have kept both.
+    expect(await testDb().purchase.count()).toBe(0);
+    expect(await testDb().enrollment.count()).toBe(0);
+  });
+
+  it("commits every write when it does not", async () => {
+    const learner = await aUserRow();
+    const author = await aUserRow({ role: "FACULTY" });
+    const { course } = await aCourseWithTopic(author.id);
+
+    await testDb().$transaction(async (tx) => {
+      await tx.purchase.create({ data: { userId: learner.id, courseId: course.id } });
+      await tx.enrollment.create({ data: { userId: learner.id, courseId: course.id } });
+    });
+
+    expect(await testDb().purchase.count()).toBe(1);
+    expect(await testDb().enrollment.count()).toBe(1);
+  });
+});
+
+describe("constraints the application relies on", () => {
+  it("refuses a second Purchase of the same Course by the same learner", async () => {
+    const learner = await aUserRow();
+    const author = await aUserRow({ role: "FACULTY" });
+    const { course } = await aCourseWithTopic(author.id);
+
+    await aPurchaseRow(learner.id, course.id);
+
+    // Stripe can deliver a webhook twice; the unique constraint is what makes
+    // reconciliation idempotent rather than the handler remembering to check.
+    await expect(aPurchaseRow(learner.id, course.id)).rejects.toThrow();
+    expect(await testDb().purchase.count()).toBe(1);
+  });
+
+  it("refuses a second Enrollment for the same learner and Course", async () => {
+    const learner = await aUserRow();
+    const author = await aUserRow({ role: "FACULTY" });
+    const { course } = await aCourseWithTopic(author.id);
+
+    await testDb().enrollment.create({ data: { userId: learner.id, courseId: course.id } });
+
+    await expect(
+      testDb().enrollment.create({ data: { userId: learner.id, courseId: course.id } })
+    ).rejects.toThrow();
+  });
+
+  it("refuses progress against a Topic that does not exist", async () => {
+    const learner = await aUserRow();
+
+    await expect(
+      testDb().userProgress.create({
+        data: { userId: learner.id, topicId: "topic_that_never_existed", isCompleted: true },
+      })
+    ).rejects.toThrow();
+  });
+
+  it("removes a Course's Modules and Topics with it", async () => {
+    const author = await aUserRow({ role: "FACULTY" });
+    const { course } = await aCourseWithTopic(author.id);
+
+    await testDb().course.delete({ where: { id: course.id } });
+
+    expect(await testDb().module.count()).toBe(0);
+    expect(await testDb().topic.count()).toBe(0);
+  });
+});

--- a/vitest.integration.config.mts
+++ b/vitest.integration.config.mts
@@ -1,0 +1,63 @@
+import { fileURLToPath } from "node:url";
+
+import { config } from "dotenv";
+import { defineConfig } from "vitest/config";
+
+// An exported TEST_DATABASE_URL or DATABASE_URL wins over the dotenv files, so
+// pointing a run at a throwaway server is one shell prefix and cannot be
+// silently overridden by .env.local (which is loaded with override: true).
+const explicit = {
+  TEST_DATABASE_URL: process.env.TEST_DATABASE_URL,
+  DATABASE_URL: process.env.DATABASE_URL,
+};
+
+config();
+config({ path: ".env.local", override: true });
+
+for (const [key, value] of Object.entries(explicit)) {
+  if (value) process.env[key] = value;
+}
+
+/**
+ * Integration suite (#107).
+ *
+ * These tests talk to a real PostgreSQL database created from the committed
+ * migrations. That is the point: RLS policies, constraints, cascades,
+ * transaction and concurrency behaviour cannot be observed against a mock, and
+ * a policy regression is invisible to the unit suite by construction
+ * (ADR 0003).
+ *
+ * Kept in its own config rather than a second project in vitest.config.mts so
+ * that `npm run test:unit` stays fast and needs no database, and so CI can run
+ * the two on different runners.
+ */
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./", import.meta.url)),
+      "server-only": fileURLToPath(
+        new URL("./node_modules/server-only/empty.js", import.meta.url)
+      ),
+    },
+  },
+  test: {
+    environment: "node",
+    include: ["tests/integration/**/*.test.ts"],
+    globalSetup: ["tests/integration/support/global-setup.ts"],
+    setupFiles: ["tests/integration/support/setup.ts"],
+
+    // A database round trip is orders of magnitude slower than a mocked call,
+    // and cloning the template plus applying migrations happens before the
+    // first test runs.
+    testTimeout: 30_000,
+    hookTimeout: 60_000,
+
+    // Each worker owns its own database, so workers are isolated from each
+    // other. Tests within a file share one, so they must not run concurrently.
+    fileParallelism: true,
+    sequence: { concurrent: false },
+
+    // No coverage thresholds here. Coverage is the unit suite's gate; this
+    // suite exists to prove behaviour that coverage cannot see.
+  },
+});


### PR DESCRIPTION
Establishes the harness for #107. Coverage accumulates with the issues that need it — final closure still requires integration coverage for #43, #44, #54, #69.

**This unblocks #43.** ADR 0003 says row-level security "cannot be tested against a mock, and a policy regression is invisible to unit tests." Without this, the first proof an RLS policy works would be production returning empty pages.

## Why a real database

The unit suite proves the *shape* of a query. Only PostgreSQL proves what it returns — that a relation name is right, that a nested filter traverses the relation it reads like, that a unique constraint holds, that a cascade fires, that a rollback discards, that two concurrent writes race the way the code assumes. A mock will happily accept two conflicting writes and honour no constraint at all.

## How it works

Global setup drops and recreates a **template** database and applies `prisma/migrations` with `prisma migrate deploy` — not a schema push — so a migration that doesn't apply cleanly fails the build here rather than in production.

Each worker clones it with `CREATE DATABASE ... TEMPLATE`, a file copy, so workers are fully isolated and cost almost nothing. Databases are named `akomapa_integration_*` and dropped in teardown, including any left by a killed run. Verified: no leftovers after a run.

`harness.test.ts` asserts the harness itself **first** — migrations applied rather than pushed, none pending, the database is disposable rather than the developer's own, and truncation between tests actually happens. A suite that silently runs against a shared or unmigrated database produces confident, meaningless results.

## First coverage — 32 tests

Chosen to prove the Wave 1 fixes at the layer that can prove them:

- **Cross-course Topic access (#39)** with both rows genuinely present and only the *relationship* differing — the exact thing a mock cannot check. Including a Topic hidden because its Module was unpublished.
- **Authoring ownership (#42)** — a Topic from another Course denied even to that Course's owner.
- **Quiz finalisation claimed exactly once (#41)** under two concurrent submissions, and the second not overwriting the first score.
- **Transaction rollback** discarding every write; commit keeping them.
- **The unique constraints that make Stripe reconciliation idempotent** — a second Purchase of the same Course is refused by the database, not by a handler remembering to check.
- **The progress route end to end (#40)**, with only the Clerk session mocked: entitlement denial, cross-course denial, non-boolean payload rejection, and a replayed completion issuing **exactly one** certificate.

## CI

New `Integration Tests` job with a `postgres:16` service container and a health check. On failure it dumps the template's migration state, so a migration problem is diagnosable from the log rather than by guessing.

Deliberately **outside `npm run validate`** — that must stay runnable without a database.

## Commands run

```
npm run test:integration     # 32 passed
npm run validate             # exit 0
```

## Notes

- Local runs need a PostgreSQL you may create and drop databases on: `TEST_DATABASE_URL=... npm run test:integration`, falling back to `DATABASE_URL`. An exported value beats the dotenv files, same precedence discipline as the role scripts.
- I could not exercise a *fresh remote server* locally — `docker-credential-desktop` is missing from PATH on this machine so image pulls fail. It matters less than it sounds: global setup drops and recreates the template every run, so the from-empty migration path is already exercised. The CI service container proves the rest.
- `Integration Tests` is not in the ruleset's required checks. Worth adding once it has settled, alongside `Unit Tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RH1AUJJFKCXc2SuRcML9vg
