### PR TITLE
fix: resolve the open code scanning findings

### DIFF
--- a/actions/get-forum-posts.ts
+++ b/actions/get-forum-posts.ts
@@ -1,4 +1,5 @@
 import { db } from "@/lib/db";
+import { excerpt } from "@/lib/text/strip-html";
 
 export interface ForumPostPreview {
   id: string;
@@ -104,7 +105,7 @@ export const getForumPosts = async (
     const mapPost = (post: PostWithIncludes): ForumPostPreview => ({
       id: post.id,
       title: post.title,
-      excerpt: stripHtml(post.content).slice(0, 150),
+      excerpt: excerpt(post.content, 150),
       author: post.user,
       category: post.category,
       course: post.course,
@@ -152,6 +153,3 @@ export const getForumPosts = async (
   }
 };
 
-function stripHtml(html: string): string {
-  return html.replace(/<[^>]*>/g, "").replace(/&nbsp;/g, " ").trim();
-}

--- a/actions/get-topic.ts
+++ b/actions/get-topic.ts
@@ -190,6 +190,6 @@ export const getTopic = async ({
             previousTopic: null,
             userProgress: null,
             purchase: null,
-        }
+        };
     }
-}
+};

--- a/app/(course)/courses/[courseId]/_components/course-sidebar.tsx
+++ b/app/(course)/courses/[courseId]/_components/course-sidebar.tsx
@@ -58,7 +58,6 @@ export const CourseSidebar = ({
 
   const preTest = quizzes.find((q) => q.type === "PRE_TEST");
   const postTest = quizzes.find((q) => q.type === "POST_TEST");
-  const moduleQuizzes = quizzes.filter((q) => q.type === "MODULE_QUIZ");
 
   return (
     <div className="h-full flex flex-col overflow-hidden border-r border-border/60 bg-card">

--- a/app/(course)/courses/[courseId]/quiz/[quizId]/_components/quiz-question.tsx
+++ b/app/(course)/courses/[courseId]/quiz/[quizId]/_components/quiz-question.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useQuizStore, QuizQuestion as QuizQuestionType } from "@/hooks/use-quiz-store";
+import { useQuizStore } from "@/hooks/use-quiz-store";
 import { cn } from "@/lib/utils";
 
 export const QuizQuestion = () => {

--- a/app/(course)/courses/[courseId]/quiz/[quizId]/take/page.tsx
+++ b/app/(course)/courses/[courseId]/quiz/[quizId]/take/page.tsx
@@ -23,10 +23,8 @@ const QuizTakePage = () => {
     setQuiz,
     tick,
     submit,
-    reset,
     timeRemaining,
     isSubmitted,
-    questions,
     answers,
     attemptId,
   } = useQuizStore();

--- a/app/(dashboard)/(routes)/admin/courses/[courseId]/quizzes/[quizId]/preview/page.tsx
+++ b/app/(dashboard)/(routes)/admin/courses/[courseId]/quizzes/[quizId]/preview/page.tsx
@@ -6,7 +6,6 @@ import { db } from "@/lib/db";
 import { requirePageCourse } from "@/lib/auth";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/utils";
 
 const QuizPreviewPage = async ({

--- a/app/(dashboard)/(routes)/admin/quizzes/page.tsx
+++ b/app/(dashboard)/(routes)/admin/quizzes/page.tsx
@@ -1,10 +1,9 @@
 import Link from "next/link";
-import { FileQuestion, Plus } from "lucide-react";
+import { FileQuestion } from "lucide-react";
 
 import { db } from "@/lib/db";
 import { requirePageCapability } from "@/lib/auth";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { PageContainer } from "@/components/shell/page-container";
 import {
   Table,

--- a/app/(dashboard)/(routes)/community/profile/[userId]/page.tsx
+++ b/app/(dashboard)/(routes)/community/profile/[userId]/page.tsx
@@ -4,6 +4,7 @@ import { redirect, notFound } from "next/navigation";
 import { ArrowLeft, Calendar } from "lucide-react";
 
 import { db } from "@/lib/db";
+import { excerpt } from "@/lib/text/strip-html";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { PostCard } from "../../_components/post-card";
 
@@ -62,7 +63,7 @@ const CommunityProfilePage = async ({
   const postPreviews = posts.map((post) => ({
     id: post.id,
     title: post.title,
-    excerpt: post.content.replace(/<[^>]*>/g, "").slice(0, 150),
+    excerpt: excerpt(post.content, 150),
     author: post.user,
     category: post.category,
     course: post.course,

--- a/app/(dashboard)/(routes)/courses/_components/enrolled-course-card.tsx
+++ b/app/(dashboard)/(routes)/courses/_components/enrolled-course-card.tsx
@@ -4,7 +4,6 @@ import { BookOpen, Layers, FileQuestion } from "lucide-react";
 
 import { StatusBadge } from "@/components/status-badge";
 import { CourseProgress } from "@/components/course-progress";
-import { IconBadge } from "@/components/icon-badge";
 import { type CourseStatus } from "@/actions/get-enrolled-courses";
 
 interface EnrolledCourseCardProps {

--- a/app/(dashboard)/(routes)/grades/[courseId]/page.tsx
+++ b/app/(dashboard)/(routes)/grades/[courseId]/page.tsx
@@ -1,7 +1,6 @@
 import { requirePagePrincipal } from "@/lib/auth";
 import { redirect } from "next/navigation";
-import Link from "next/link";
-import { ArrowLeft, CheckCircle2, Circle, Clock } from "lucide-react";
+import { CheckCircle2, Circle, Clock } from "lucide-react";
 
 import { getGradesDetail } from "@/actions/get-grades-detail";
 import { getCertificate } from "@/actions/get-certificate";

--- a/app/(dashboard)/(routes)/journal/_components/journal-list.tsx
+++ b/app/(dashboard)/(routes)/journal/_components/journal-list.tsx
@@ -3,6 +3,8 @@
 import { Lock, Globe, BookOpen, Calendar } from "lucide-react";
 import Link from "next/link";
 
+import { stripHtml } from "@/lib/text/strip-html";
+
 interface JournalEntry {
   id: string;
   title: string;
@@ -16,10 +18,6 @@ interface JournalEntry {
 
 interface JournalListProps {
   entries: JournalEntry[];
-}
-
-function stripHtml(html: string): string {
-  return html.replace(/<[^>]*>/g, "").trim();
 }
 
 export const JournalList = ({ entries }: JournalListProps) => {

--- a/app/(dashboard)/(routes)/journal/new/_components/journal-editor.tsx
+++ b/app/(dashboard)/(routes)/journal/new/_components/journal-editor.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
+import { stripHtml } from "@/lib/text/strip-html";
 import axios from "axios";
 import toast from "react-hot-toast";
 import { ArrowLeft, Save, Trash2 } from "lucide-react";
@@ -60,11 +61,7 @@ export const JournalEditor = ({
   const selectedCourse = courses.find((c) => c.id === courseId);
   const modules = selectedCourse?.modules ?? [];
 
-  const wordCount = content
-    .replace(/<[^>]*>/g, "")
-    .trim()
-    .split(/\s+/)
-    .filter(Boolean).length;
+  const wordCount = stripHtml(content).split(/\s+/).filter(Boolean).length;
 
   const save = useCallback(async () => {
     if (!title.trim() || !content.trim()) return;

--- a/app/(dashboard)/(routes)/teacher/courses/[courseId]/_components/attachment-form.tsx
+++ b/app/(dashboard)/(routes)/teacher/courses/[courseId]/_components/attachment-form.tsx
@@ -2,11 +2,10 @@
 
 import * as z from "zod";
 import axios from "axios";
-import { File, ImageIcon, Loader2, Pencil, PlusCircle, X } from "lucide-react";
+import { File, Loader2, PlusCircle, X } from "lucide-react";
 import { useState } from "react";
 import toast from "react-hot-toast";
 import { Attachment, Course } from "@prisma/client";
-import Image from "next/image";
 import { useRouter } from "next/navigation";
 
 

--- a/app/(dashboard)/(routes)/teacher/courses/[courseId]/_components/category-form.tsx
+++ b/app/(dashboard)/(routes)/teacher/courses/[courseId]/_components/category-form.tsx
@@ -19,7 +19,6 @@ import {
 import { Button } from "@/components/ui/button"; 
 import { useRouter } from "next/navigation";
 import { cn } from "@/lib/utils";
-import { Textarea } from "@/components/ui/textarea";
 import { Combobox } from "@/components/ui/combobox";
 
 
@@ -33,7 +32,6 @@ const formSchema = z.object({
     categoryId: z.string().min(1),
 });
 
-const testOptions = [{ label: "Option 1", value: "1" }, { label: "Option 2", value: "2" }];
 
 export const CategoryForm = ({
     initialData,

--- a/app/(dashboard)/(routes)/teacher/courses/[courseId]/_components/chapters-form.tsx
+++ b/app/(dashboard)/(routes)/teacher/courses/[courseId]/_components/chapters-form.tsx
@@ -4,7 +4,7 @@ import * as z from "zod";
 import axios from "axios";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
-import { Loader2, Pencil, PlusCircle } from "lucide-react";
+import { Loader2, PlusCircle } from "lucide-react";
 import { useState } from "react";
 import toast from "react-hot-toast";
 import { Course, Topic } from "@prisma/client";
@@ -19,7 +19,6 @@ import {
 import { Button } from "@/components/ui/button"; 
 import { useRouter } from "next/navigation";
 import { cn } from "@/lib/utils";
-import { Textarea } from "@/components/ui/textarea";
 import { Input } from "@/components/ui/input";
 import { ChaptersList } from "./chapters-list";
 

--- a/app/(dashboard)/(routes)/teacher/courses/[courseId]/_components/price-form.tsx
+++ b/app/(dashboard)/(routes)/teacher/courses/[courseId]/_components/price-form.tsx
@@ -19,7 +19,6 @@ import {
 import { Button } from "@/components/ui/button"; 
 import { useRouter } from "next/navigation";
 import { cn } from "@/lib/utils";
-import { Textarea } from "@/components/ui/textarea";
 import { Input } from "@/components/ui/input";
 import { formatPrice } from "@/lib/format";
 

--- a/app/(dashboard)/(routes)/teacher/courses/[courseId]/chapters/[chapterId]/_components/chapter-access-form.tsx
+++ b/app/(dashboard)/(routes)/teacher/courses/[courseId]/chapters/[chapterId]/_components/chapter-access-form.tsx
@@ -9,19 +9,10 @@ import { useState } from "react";
 import toast from "react-hot-toast";
 import { Topic } from "@prisma/client";
 
-import {
-    Form,
-    FormControl,
-    FormDescription,
-    FormField,
-    FormItem,
-    FormMessage
-} from "@/components/ui/form";
+import { Form, FormControl, FormDescription, FormField, FormItem } from "@/components/ui/form";
 import { Button } from "@/components/ui/button"; 
 import { useRouter } from "next/navigation";
 import { cn } from "@/lib/utils";
-import { Editor } from "@/components/editor";
-import { Preview } from "@/components/preview";
 import { Checkbox } from "@/components/ui/checkbox";
 
 

--- a/app/(dashboard)/(routes)/teacher/courses/[courseId]/chapters/[chapterId]/_components/chapter-video-form.tsx
+++ b/app/(dashboard)/(routes)/teacher/courses/[courseId]/chapters/[chapterId]/_components/chapter-video-form.tsx
@@ -7,7 +7,6 @@ import { Pencil, PlusCircle, VideoIcon } from "lucide-react";
 import { useState } from "react";
 import toast from "react-hot-toast";
 import { Topic, MuxData } from "@prisma/client";
-import Image from "next/image";
 import { useRouter } from "next/navigation";
 
 

--- a/app/(dashboard)/(routes)/teacher/courses/[courseId]/chapters/[chapterId]/page.tsx
+++ b/app/(dashboard)/(routes)/teacher/courses/[courseId]/chapters/[chapterId]/page.tsx
@@ -39,7 +39,7 @@ const ChapterIdPAge = async ({
         chapter.title,
         chapter.description,
         chapter.videoUrl,
-    ]
+    ];
 
     const totalFields = requiredFields.length;
     const completedFields = requiredFields.filter(Boolean).length;
@@ -135,6 +135,6 @@ const ChapterIdPAge = async ({
             </div>
         </>
     );
-}
+};
  
 export default ChapterIdPAge;

--- a/app/api/courses/[courseId]/chapters/route.ts
+++ b/app/api/courses/[courseId]/chapters/route.ts
@@ -57,6 +57,6 @@ export async function POST(
         if (denied) return denied;
 
         logError("CHAPTERS", error);
-        return new NextResponse("Internal Server Error", { status: 500 })
+        return new NextResponse("Internal Server Error", { status: 500 });
     }
 }

--- a/app/api/uploadthing/core.ts
+++ b/app/api/uploadthing/core.ts
@@ -19,7 +19,6 @@ const handleAuth = async () => {
     return { userId: principal.userId };
 }
  
-const auth = (req: Request) => ({ id: "fakeId" });
  
 export const ourFileRouter = {
     courseImage: f({ image: { maxFileSize: "4MB", maxFileCount: 1 } })

--- a/app/api/webhook/route.ts
+++ b/app/api/webhook/route.ts
@@ -19,7 +19,7 @@ export async function POST(req: Request) {
             body,
             signature,
             requireEnv("STRIPE_WEBHOOK_SECRET")
-        )
+        );
     } catch (error: any) {
         return new NextResponse(`Webhook Error: ${error.message}`, { status: 400 });
     }

--- a/components/ui/combobox.tsx
+++ b/components/ui/combobox.tsx
@@ -5,14 +5,7 @@ import { Check, ChevronsUpDown } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "@/components/ui/command"
+import { Command, CommandEmpty, CommandInput, CommandItem, CommandList } from "@/components/ui/command"
 import {
   Popover,
   PopoverContent,

--- a/hooks/use-quiz-store.ts
+++ b/hooks/use-quiz-store.ts
@@ -168,13 +168,12 @@ export const useQuizStore = create<QuizState>((set, get) => ({
   tick: () => {
     const state = get();
     if (state.startedAt) {
-      // Use actual elapsed time for accuracy
-      const elapsed = Math.floor((Date.now() - state.startedAt) / 1000);
-      const totalTime =
-        state.timeRemaining + elapsed - (state.timeRemaining > 0 ? 0 : 0);
-      // Simpler approach: just decrement
-      const newTime = Math.max(0, state.timeRemaining - 1);
-      set({ timeRemaining: newTime });
+      // Decrement by one tick. An abandoned attempt at computing elapsed time
+      // from `startedAt` was left here unused; the server is the authority on
+      // the time limit either way (the submit route rejects a late submission),
+      // so this only drives the countdown the learner sees. #64 owns making
+      // the client clock survive a reconnection.
+      set({ timeRemaining: Math.max(0, state.timeRemaining - 1) });
     }
   },
 

--- a/lib/text/strip-html.ts
+++ b/lib/text/strip-html.ts
@@ -1,0 +1,48 @@
+/**
+ * Reduces rich text to a plain-text excerpt.
+ *
+ * This is **not** a sanitizer and must never be used to produce HTML. It exists
+ * to make previews and list summaries out of stored rich text, and its output
+ * belongs in a JSX text node, where React escapes it.
+ *
+ * Two copies of a one-line version of this lived in the codebase, each doing a
+ * single `replace(/<[^>]*>/g, "")`. One pass is not enough:
+ *
+ *   - `<<div>script>` leaves `<script>` behind, because removing the inner tag
+ *     re-forms a tag out of the characters either side of it.
+ *   - An unterminated `<script` has no closing `>`, so the pattern never
+ *     matches it and it survives verbatim.
+ *
+ * So the pass repeats until the string stops changing, and any `<` still
+ * standing afterwards is removed outright. Nothing that could open a tag
+ * survives, which is what makes the result safe to treat as text.
+ *
+ * Rendering stored rich text *as HTML* is a different problem with a different
+ * answer -- a real sanitizer with an allow-list -- and belongs to
+ * [#81](https://github.com/akomapahealth/akomapa-lms/issues/81).
+ */
+export function stripHtml(html: string): string {
+  if (!html) return "";
+
+  let current = html;
+  let previous: string;
+
+  do {
+    previous = current;
+    current = current.replace(/<[^>]*>/g, "");
+  } while (current !== previous);
+
+  return current
+    // Anything left that could still begin a tag.
+    .replace(/</g, "")
+    // The entity a rich-text editor emits most often; without this, excerpts
+    // read as "one&nbsp;two".
+    .replace(/&nbsp;/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** A plain-text excerpt of at most `length` characters. */
+export function excerpt(html: string, length: number): string {
+  return stripHtml(html).slice(0, length);
+}

--- a/tests/unit/text/strip-html.test.ts
+++ b/tests/unit/text/strip-html.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { excerpt, stripHtml } from "@/lib/text/strip-html";
+
+/**
+ * The cases that made the previous single-pass version wrong.
+ *
+ * CodeQL flagged four call sites for `js/incomplete-multi-character-sanitization`.
+ * The output goes into JSX text nodes, where React escapes it, so nothing was
+ * exploitable -- but "safe because of where it happens to be rendered" is not a
+ * property worth relying on, and the next caller may not render it that way.
+ */
+describe("stripHtml", () => {
+  it("removes ordinary tags", () => {
+    expect(stripHtml("<p>Hello <strong>world</strong></p>")).toBe("Hello world");
+  });
+
+  it("neutralises a tag re-formed by removing the tag inside it", () => {
+    // One pass over `<<div>script>alert(1)` consumes `<<div>` and leaves
+    // `script>alert(1)`. What remains is inert text -- the point is that no `<`
+    // survives to open a tag, not that every character disappears.
+    const result = stripHtml("<<div>script>alert(1)");
+
+    expect(result).toBe("script>alert(1)");
+    expect(result).not.toContain("<");
+  });
+
+  it("neutralises an unterminated tag, which no `<[^>]*>` pattern can match", () => {
+    // `<script` has no closing `>`, so the pattern never matches it. The old
+    // version returned it verbatim, which is what CodeQL flagged.
+    expect(stripHtml("<script")).toBe("script");
+    expect(stripHtml("hello <script")).toBe("hello script");
+  });
+
+  it("leaves nothing that could open a tag", () => {
+    for (const input of [
+      "<script>alert(1)</script>",
+      "<<script>script>alert(1)",
+      "<img src=x onerror=alert(1)>",
+      "<<<>>>",
+      "a < b",
+    ]) {
+      expect(stripHtml(input)).not.toContain("<");
+    }
+  });
+
+  it("decodes the non-breaking space a rich-text editor emits", () => {
+    expect(stripHtml("<p>one&nbsp;two</p>")).toBe("one two");
+  });
+
+  it("collapses whitespace so a preview reads as one line", () => {
+    expect(stripHtml("<p>one</p>\n\n<p>two</p>")).toBe("one two");
+  });
+
+  it("handles empty and absent input", () => {
+    expect(stripHtml("")).toBe("");
+    expect(stripHtml(undefined as unknown as string)).toBe("");
+  });
+
+  it("leaves plain text alone", () => {
+    expect(stripHtml("Just a sentence.")).toBe("Just a sentence.");
+  });
+});
+
+describe("excerpt", () => {
+  it("truncates after stripping, not before", () => {
+    // Truncating first can cut a tag in half and leave `<scr` in the output.
+    const html = `<p>${"a".repeat(200)}</p>`;
+
+    expect(excerpt(html, 10)).toBe("a".repeat(10));
+  });
+
+  it("returns the whole string when it is shorter than the limit", () => {
+    expect(excerpt("<p>short</p>", 150)).toBe("short");
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -49,6 +49,7 @@ export default defineConfig({
         "lib/auth/*.ts",
         "lib/courses/*.ts",
         "lib/assessments/*.ts",
+        "lib/text/*.ts",
         "lib/streak-service.ts",
         "lib/badge-service.ts",
         "lib/certificate-service.ts",
@@ -73,6 +74,9 @@ export default defineConfig({
         "lib/courses/completion.ts": { lines: 100, functions: 100, branches: 100, statements: 100 },
         // Grading feeds certificates and analytics.
         "lib/assessments/grading.ts": { lines: 100, functions: 100, branches: 100, statements: 100 },
+        // Excerpt generation from stored rich text; CodeQL flagged the previous
+        // single-pass version at four call sites.
+        "lib/text/strip-html.ts": { lines: 100, functions: 100, branches: 100, statements: 100 },
       },
     },
   },


### PR DESCRIPTION
Clears the 33 open CodeQL alerts. **None of them were introduced by the recent PRs** — they're pre-existing repo-wide findings that CodeQL re-reports on every PR, which is why they looked like they came from #144.

Four were high severity. The rest were noise, and noise is the real problem: a security tab with 33 entries trains people to stop reading it.

## The four high alerts

`js/incomplete-multi-character-sanitization`, on two copies of a one-line `stripHtml` each doing a single `replace(/<[^>]*>/g, "")`. One pass isn't enough:

- `<<div>script>alert(1)` → removing `<<div>` re-forms text out of the characters either side.
- `<script` has no closing `>`, so the pattern **never matches it** and it survives verbatim.

**Nothing was exploitable.** All four call sites render into JSX text nodes, where React escapes the result. But "safe because of where it happens to be rendered" isn't a property worth relying on, and the next caller may not render it that way.

The two copies are now one helper (`lib/text/strip-html.ts`) that repeats the pass until the string stops changing, then removes any `<` still standing — so nothing that can open a tag survives. Verified by restoring the old single-pass version and watching two tests fail.

## ⚠️ The finding CodeQL missed

Tracing those call sites turned up something worse. `case-study-player.tsx` renders three fields through `dangerouslySetInnerHTML` with **no sanitization at all**:

```tsx
dangerouslySetInnerHTML={{ __html: scenario.introduction }}
dangerouslySetInnerHTML={{ __html: scenario.conclusion }}
dangerouslySetInnerHTML={{ __html: currentStep.narrative }}
```

CodeQL doesn't flag it *precisely because* there's no sanitizer there to call incomplete. It only complains about sanitizers that look wrong, not about their absence.

This is **stored XSS against learners**, written by a Course author. Severity is bounded by #42 — the attacker must be FACULTY or ADMIN and must own the Course — so it isn't anonymous, but a compromised or malicious author reaches every learner on that Course.

**I have not fixed it here.** A correct fix needs a real sanitizer with an allow-list policy, which is exactly [#81](https://github.com/akomapahealth/akomapa-lms/issues/81)'s brief (`security`, `release-blocker`). Half-sanitizing would be worse than a clear finding.

## A landmine, removed

`app/api/uploadthing/core.ts` contained:

```ts
const auth = (req: Request) => ({ id: "fakeId" });
```

Unused, sitting directly beside the real authentication helper. CodeQL flagged it only as an unused variable. A function of that name returning a fabricated identity is worth deleting on its own merits.

## Scope held deliberately

The remaining alerts were unused imports and missing semicolons — all fixed. But I did **not** run the rules repo-wide:

| Rule | CodeQL flags | Rule finds repo-wide |
| --- | --- | --- |
| `semi` | 4 | **544** |
| `no-unused-vars` | 25 | **341** |

A sweep that size would bury this change and make it unreviewable. Both are worth doing as their own PR with the rule enabled to prevent recurrence — say the word and I'll open it.

## Commands run

```
npm run validate        # exit 0
npm run build

Test Files  15 passed (15)
     Tests  384 passed (384)

Statements : 99.07%   Branches : 96.65%
Functions  : 100%     Lines    : 100%
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RH1AUJJFKCXc2SuRcML9vg
