### PR TITLE
chore: enable semi and no-unused-vars, and clear what they find

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,8 @@
     "plugin:security/recommended-legacy"
   ],
   "plugins": [
-    "security"
+    "security",
+    "@typescript-eslint"
   ],
   "rules": {
     "security/detect-object-injection": "off",
@@ -24,6 +25,20 @@
           }
         ]
       }
+    ],
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        "args": "after-used",
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_",
+        "caughtErrors": "none",
+        "ignoreRestSiblings": true
+      }
+    ],
+    "semi": [
+      "error",
+      "always"
     ]
   },
   "overrides": [

--- a/actions/get-analytics.ts
+++ b/actions/get-analytics.ts
@@ -46,13 +46,13 @@ export const getAnalytics = async (userId: string) => {
             data,
             totalRevenue,
             totalSales,
-        }
+        };
     } catch (error) {
         console.log("[GET_ANALYTICS]", error);
         return {
             data: [],
             totalRevenue: 0,
             totalSales: 0,
-        }
+        };
     }
-}
+};

--- a/actions/get-courses.ts
+++ b/actions/get-courses.ts
@@ -63,7 +63,7 @@ export const getCourses = async ({
                     return {
                         ...course,
                         progress: null,
-                    }
+                    };
                 }
 
                 const progressPercentage = await getProgress(userId, course.id);
@@ -71,7 +71,7 @@ export const getCourses = async ({
                 return {
                     ...course,
                     progress: progressPercentage,
-                }
+                };
             })
         );
 
@@ -80,4 +80,4 @@ export const getCourses = async ({
         console.log("[GET_COURSES]", error);
         return [];
     }
-}
+};

--- a/actions/get-dashboard-courses.ts
+++ b/actions/get-dashboard-courses.ts
@@ -53,12 +53,12 @@ export const getDashboardCourses = async (userId: string): Promise<DashboardCour
         return {
             completedCourses,
             coursesInProgress,
-        }
+        };
     } catch (error) {
         console.log("[GET_DASHBOARD_COURSES]", error);
         return {
             completedCourses: [],
             coursesInProgress: [],
-        }
+        };
     }
-}
+};

--- a/actions/get-progress.ts
+++ b/actions/get-progress.ts
@@ -41,4 +41,4 @@ export const getProgress = async (
         console.log("[GET_PROGRESS]", error);
         return 0;
     }
-}
+};

--- a/app/(course)/courses/[courseId]/_components/course-sidebar-item.tsx
+++ b/app/(course)/courses/[courseId]/_components/course-sidebar-item.tsx
@@ -28,7 +28,7 @@ export const CourseSidebarItem = ({
 
     const onClick = () => {
         router.push(`/courses/${courseId}/chapters/${id}`);
-    }
+    };
     return (
         <button
             onClick={onClick}
@@ -59,5 +59,5 @@ export const CourseSidebarItem = ({
                 )}
             />
         </button>
-    )
-}
+    );
+};

--- a/app/(course)/courses/[courseId]/chapters/[chapterId]/_components/course-enroll-button.tsx
+++ b/app/(course)/courses/[courseId]/chapters/[chapterId]/_components/course-enroll-button.tsx
@@ -30,7 +30,7 @@ export const CourseEnrollButton = ({
         } finally {
             setIsLoading(false);
         }
-    }
+    };
 
     return (
         <Button
@@ -41,5 +41,5 @@ export const CourseEnrollButton = ({
         >
             Enroll for {formatPrice(price)}
         </Button>
-    )
-}
+    );
+};

--- a/app/(course)/courses/[courseId]/chapters/[chapterId]/_components/course-progress-button.tsx
+++ b/app/(course)/courses/[courseId]/chapters/[chapterId]/_components/course-progress-button.tsx
@@ -83,7 +83,7 @@ export const CourseProgressButton = ({
         } finally {
             setIsLoading(false);
         }
-    }
+    };
 
     const Icon = isCompleted ? XCircle : CheckCircle;
     return (
@@ -109,5 +109,5 @@ export const CourseProgressButton = ({
                 />
             )}
         </>
-    )
-}
+    );
+};

--- a/app/(course)/courses/[courseId]/chapters/[chapterId]/_components/video-player.tsx
+++ b/app/(course)/courses/[courseId]/chapters/[chapterId]/_components/video-player.tsx
@@ -54,7 +54,7 @@ export const VideoPlayer = ({
         } catch {
             toast.error("Something went wrong");
         }
-    }
+    };
 
     return (
         <div className="relative aspect-video">
@@ -84,5 +84,5 @@ export const VideoPlayer = ({
                 />
             )}
         </div>
-    )
-}
+    );
+};

--- a/app/(course)/courses/[courseId]/chapters/[chapterId]/page.tsx
+++ b/app/(course)/courses/[courseId]/chapters/[chapterId]/page.tsx
@@ -190,6 +190,6 @@ const ChapterIdPage = async ({
             </div>
         </div>
      );
-}
+};
 
 export default ChapterIdPage;

--- a/app/(course)/courses/[courseId]/layout.tsx
+++ b/app/(course)/courses/[courseId]/layout.tsx
@@ -68,7 +68,7 @@ const CourseLayout = async ({
                 },
             },
         },
-    })
+    });
 
     if (!course) {
         return redirect("/dashboard");
@@ -116,6 +116,6 @@ const CourseLayout = async ({
             {children}
         </AppShell>
     );
-}
+};
 
 export default CourseLayout;

--- a/app/(dashboard)/(routes)/community/new/page.tsx
+++ b/app/(dashboard)/(routes)/community/new/page.tsx
@@ -1,6 +1,5 @@
 import { requirePagePrincipal } from "@/lib/auth";
 import Link from "next/link";
-import { redirect } from "next/navigation";
 import { ArrowLeft } from "lucide-react";
 
 import { db } from "@/lib/db";

--- a/app/(dashboard)/(routes)/community/page.tsx
+++ b/app/(dashboard)/(routes)/community/page.tsx
@@ -1,6 +1,5 @@
 import { requirePagePrincipal } from "@/lib/auth";
 import Link from "next/link";
-import { redirect } from "next/navigation";
 import { Plus } from "lucide-react";
 
 import { db } from "@/lib/db";

--- a/app/(dashboard)/(routes)/community/profile/[userId]/page.tsx
+++ b/app/(dashboard)/(routes)/community/profile/[userId]/page.tsx
@@ -1,6 +1,6 @@
 import { requirePagePrincipal } from "@/lib/auth";
 import Link from "next/link";
-import { redirect, notFound } from "next/navigation";
+import { notFound } from "next/navigation";
 import { ArrowLeft, Calendar } from "lucide-react";
 
 import { db } from "@/lib/db";

--- a/app/(dashboard)/(routes)/courses/page.tsx
+++ b/app/(dashboard)/(routes)/courses/page.tsx
@@ -1,5 +1,4 @@
 import { requirePagePrincipal } from "@/lib/auth";
-import { redirect } from "next/navigation";
 
 import { getEnrolledCourses } from "@/actions/get-enrolled-courses";
 import { getEnrolledModules } from "@/actions/get-enrolled-modules";

--- a/app/(dashboard)/(routes)/dashboard/_components/info-card.tsx
+++ b/app/(dashboard)/(routes)/dashboard/_components/info-card.tsx
@@ -1,4 +1,4 @@
-import { IconBadge } from "@/components/icon-badge"
+import { IconBadge } from "@/components/icon-badge";
 import { LucideIcon } from "lucide-react";
 
 interface InfoCardProps {
@@ -29,5 +29,5 @@ export const InfoCard = ({
                 </p>
             </div>
         </div>
-    )
-}
+    );
+};

--- a/app/(dashboard)/(routes)/dashboard/page.tsx
+++ b/app/(dashboard)/(routes)/dashboard/page.tsx
@@ -1,5 +1,4 @@
 import { requirePagePrincipal } from "@/lib/auth";
-import { redirect } from "next/navigation";
 
 import { getEnrolledCourses } from "@/actions/get-enrolled-courses";
 import { getCourseProgressBreakdown } from "@/actions/get-course-progress-breakdown";

--- a/app/(dashboard)/(routes)/grades/page.tsx
+++ b/app/(dashboard)/(routes)/grades/page.tsx
@@ -1,5 +1,4 @@
 import { requirePagePrincipal } from "@/lib/auth";
-import { redirect } from "next/navigation";
 import Link from "next/link";
 import { ArrowUp, ArrowDown, GraduationCap } from "lucide-react";
 

--- a/app/(dashboard)/(routes)/journal/[entryId]/page.tsx
+++ b/app/(dashboard)/(routes)/journal/[entryId]/page.tsx
@@ -1,5 +1,4 @@
 import { requirePagePrincipal } from "@/lib/auth";
-import { redirect } from "next/navigation";
 import { notFound } from "next/navigation";
 
 import { db } from "@/lib/db";

--- a/app/(dashboard)/(routes)/journal/new/page.tsx
+++ b/app/(dashboard)/(routes)/journal/new/page.tsx
@@ -1,5 +1,4 @@
 import { requirePagePrincipal } from "@/lib/auth";
-import { redirect } from "next/navigation";
 
 import { db } from "@/lib/db";
 import { JournalEditor } from "./_components/journal-editor";

--- a/app/(dashboard)/(routes)/journal/page.tsx
+++ b/app/(dashboard)/(routes)/journal/page.tsx
@@ -1,5 +1,4 @@
 import { requirePagePrincipal } from "@/lib/auth";
-import { redirect } from "next/navigation";
 import Link from "next/link";
 
 import { getJournalEntries } from "@/actions/get-journal-entries";

--- a/app/(dashboard)/(routes)/learning-path/page.tsx
+++ b/app/(dashboard)/(routes)/learning-path/page.tsx
@@ -1,5 +1,4 @@
 import { requirePagePrincipal } from "@/lib/auth";
-import { redirect } from "next/navigation";
 import { Map } from "lucide-react";
 
 import { getLearningPath } from "@/actions/get-learning-path";

--- a/app/(dashboard)/(routes)/search/_components/categories.tsx
+++ b/app/(dashboard)/(routes)/search/_components/categories.tsx
@@ -1,4 +1,4 @@
-"use client"
+"use client";
 
 import { Category } from "@prisma/client";
 import {
@@ -25,7 +25,7 @@ const iconMap: Record<Category["name"], IconType> = {
     "Engineering": FcEngineering,
     "Accounting": FcSalesPerformance,
     "Computer Science": FcMultipleDevices
-}
+};
 
 export const Categories = ({
     items,
@@ -41,5 +41,5 @@ export const Categories = ({
                 />
             ))}
         </div>
-    )
-}
+    );
+};

--- a/app/(dashboard)/(routes)/search/_components/category-item.tsx
+++ b/app/(dashboard)/(routes)/search/_components/category-item.tsx
@@ -1,4 +1,4 @@
-"use client"
+"use client";
 
 import qs from "query-string";
 
@@ -37,7 +37,7 @@ export const CategoryItem = ({
         }, {skipNull: true, skipEmptyString: true});
 
         router.push(url);
-    }
+    };
 
     return (
         <button 
@@ -53,5 +53,5 @@ export const CategoryItem = ({
                 {label}
             </div>
         </button>
-    )
-}
+    );
+};

--- a/app/(dashboard)/(routes)/search/page.tsx
+++ b/app/(dashboard)/(routes)/search/page.tsx
@@ -1,5 +1,4 @@
 import { requirePagePrincipal } from "@/lib/auth";
-import { redirect } from "next/navigation";
 import { Suspense } from "react";
 
 import { db } from "@/lib/db";
@@ -55,6 +54,6 @@ const SearchPage = async ({
             </PageContainer>
         </>
      );
-}
+};
  
 export default SearchPage;

--- a/app/(dashboard)/(routes)/settings/page.tsx
+++ b/app/(dashboard)/(routes)/settings/page.tsx
@@ -1,5 +1,4 @@
 import { requirePagePrincipal } from "@/lib/auth";
-import { redirect } from "next/navigation";
 
 import { getUserSettings } from "@/actions/get-user-settings";
 

--- a/app/(dashboard)/(routes)/teacher/analytics/_components/chart.tsx
+++ b/app/(dashboard)/(routes)/teacher/analytics/_components/chart.tsx
@@ -46,5 +46,5 @@ export const Chart = ({
                 </BarChart>
             </ResponsiveContainer>
         </Card>
-    )
-}
+    );
+};

--- a/app/(dashboard)/(routes)/teacher/analytics/page.tsx
+++ b/app/(dashboard)/(routes)/teacher/analytics/page.tsx
@@ -1,5 +1,4 @@
 import { requirePagePrincipal } from "@/lib/auth";
-import { redirect } from "next/navigation";
 
 import { getAnalytics } from "@/actions/get-analytics";
 import { DataCard } from "@/components/admin/data-card";
@@ -31,6 +30,6 @@ const AnalyticsPage = async () => {
             />
         </PageContainer>
      );
-}
+};
  
 export default AnalyticsPage;

--- a/app/(dashboard)/(routes)/teacher/courses/[courseId]/_components/actions.tsx
+++ b/app/(dashboard)/(routes)/teacher/courses/[courseId]/_components/actions.tsx
@@ -46,7 +46,7 @@ export const Actions = ({
         } finally {
             setIsLoading(false);
         }
-    }
+    };
 
     const onDelete = async () => {
         try {
@@ -62,7 +62,7 @@ export const Actions = ({
         } finally {
             setIsLoading(false);
         }
-    }
+    };
 
 
     return (
@@ -83,5 +83,5 @@ export const Actions = ({
                 </Button>
             </ConfirmModal>
         </div>
-    )
-}
+    );
+};

--- a/app/(dashboard)/(routes)/teacher/courses/[courseId]/_components/attachment-form.tsx
+++ b/app/(dashboard)/(routes)/teacher/courses/[courseId]/_components/attachment-form.tsx
@@ -18,6 +18,11 @@ interface AttachmentFormProps {
     courseId: string;
 };
 
+// Declared but never enforced: this form submits from a callback rather
+// than through zodResolver, so the schema only supplies a type. Left in
+// place rather than deleted -- the shape it documents is correct, and
+// wiring it up is a behaviour change that belongs with the form work.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const formSchema = z.object({
     url: z.string().min(1),
 });
@@ -55,7 +60,7 @@ export const AttachmentForm = ({
         } finally {
             setDeletingId(null);
         }
-    }
+    };
 
     return (
         <div className="mt-6 border bg-muted rounded-md p-4">
@@ -127,4 +132,4 @@ export const AttachmentForm = ({
             )}
         </div>
     );
-}
+};

--- a/app/(dashboard)/(routes)/teacher/courses/[courseId]/_components/category-form.tsx
+++ b/app/(dashboard)/(routes)/teacher/courses/[courseId]/_components/category-form.tsx
@@ -62,7 +62,7 @@ export const CategoryForm = ({
         } catch {
             toast.error("Something went wrong");
         }
-    }
+    };
 
     const selectedOption = options.find((option) => option.value === initialData.categoryId);
 
@@ -123,4 +123,4 @@ export const CategoryForm = ({
             )}
         </div>
     );
-}
+};

--- a/app/(dashboard)/(routes)/teacher/courses/[courseId]/_components/chapters-form.tsx
+++ b/app/(dashboard)/(routes)/teacher/courses/[courseId]/_components/chapters-form.tsx
@@ -41,7 +41,7 @@ export const ChaptersForm = ({
 
     const toggleCreating = () => {
         setIsCreating((current) => !current);
-    }
+    };
 
     const router = useRouter();
 
@@ -63,7 +63,7 @@ export const ChaptersForm = ({
         } catch {
             toast.error("Something went wrong");
         }
-    }
+    };
 
     const onReorder = async (updateData: { id: string; position: number }[]) => {
         try {
@@ -79,11 +79,11 @@ export const ChaptersForm = ({
         } finally {
             setIsUpdating(false);
         }
-    }
+    };
 
     const onEdit = (id: string) => {
         router.push(`/teacher/courses/${courseId}/chapters/${id}`);
-    }
+    };
 
     return (
         <div className="relative mt-6 border bg-muted rounded-md p-4">
@@ -157,4 +157,4 @@ export const ChaptersForm = ({
             )}
         </div>
     );
-}
+};

--- a/app/(dashboard)/(routes)/teacher/courses/[courseId]/_components/chapters-list.tsx
+++ b/app/(dashboard)/(routes)/teacher/courses/[courseId]/_components/chapters-list.tsx
@@ -29,7 +29,7 @@ export const ChaptersList = ({
     const [chapters, setChapters] = useState(items);
 
     useEffect(() => {
-        setIsMounted(true)
+        setIsMounted(true);
     }, []);
 
     useEffect(() => {
@@ -59,7 +59,7 @@ export const ChaptersList = ({
         }));
 
         onReorder(bulkUpdateData);
-    }
+    };
 
     if (!isMounted) {
         return null;
@@ -127,5 +127,5 @@ export const ChaptersList = ({
                 )}
             </Droppable>
         </DragDropContext>
-    )
-}
+    );
+};

--- a/app/(dashboard)/(routes)/teacher/courses/[courseId]/_components/description-form.tsx
+++ b/app/(dashboard)/(routes)/teacher/courses/[courseId]/_components/description-form.tsx
@@ -61,7 +61,7 @@ export const DescriptionForm = ({
         } catch {
             toast.error("Something went wrong");
         }
-    }
+    };
 
     return (
         <div className="mt-6 border bg-muted rounded-md p-4">
@@ -121,4 +121,4 @@ export const DescriptionForm = ({
             )}
         </div>
     );
-}
+};

--- a/app/(dashboard)/(routes)/teacher/courses/[courseId]/_components/image-form.tsx
+++ b/app/(dashboard)/(routes)/teacher/courses/[courseId]/_components/image-form.tsx
@@ -19,6 +19,11 @@ interface ImageFormProps {
     courseId: string;
 };
 
+// Declared but never enforced: this form submits from a callback rather
+// than through zodResolver, so the schema only supplies a type. Left in
+// place rather than deleted -- the shape it documents is correct, and
+// wiring it up is a behaviour change that belongs with the form work.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const formSchema = z.object({
     imageUrl: z.string().min(1, {
         message: "Image is required",
@@ -44,7 +49,7 @@ export const ImageForm = ({
         } catch {
             toast.error("Something went wrong");
         }
-    }
+    };
 
     return (
         <div className="mt-6 border bg-muted rounded-md p-4">
@@ -102,4 +107,4 @@ export const ImageForm = ({
             )}
         </div>
     );
-}
+};

--- a/app/(dashboard)/(routes)/teacher/courses/[courseId]/_components/price-form.tsx
+++ b/app/(dashboard)/(routes)/teacher/courses/[courseId]/_components/price-form.tsx
@@ -60,7 +60,7 @@ export const PriceForm = ({
         } catch {
             toast.error("Something went wrong");
         }
-    }
+    };
 
     return (
         <div className="mt-6 border bg-muted rounded-md p-4">
@@ -125,4 +125,4 @@ export const PriceForm = ({
             )}
         </div>
     );
-}
+};

--- a/app/(dashboard)/(routes)/teacher/courses/[courseId]/_components/title-form.tsx
+++ b/app/(dashboard)/(routes)/teacher/courses/[courseId]/_components/title-form.tsx
@@ -59,7 +59,7 @@ export const TitleForm = ({
         } catch {
             toast.error("Something went wrong");
         }
-    }
+    };
 
     return (
         <div className="mt-6 border bg-muted rounded-md p-4">
@@ -116,4 +116,4 @@ export const TitleForm = ({
             )}
         </div>
     );
-}
+};

--- a/app/(dashboard)/(routes)/teacher/courses/[courseId]/chapters/[chapterId]/_components/chapter-access-form.tsx
+++ b/app/(dashboard)/(routes)/teacher/courses/[courseId]/chapters/[chapterId]/_components/chapter-access-form.tsx
@@ -55,7 +55,7 @@ export const ChapterAccessForm = ({
         } catch {
             toast.error("Something went wrong");
         }
-    }
+    };
 
     return (
         <div className="mt-6 border bg-muted rounded-md p-4">
@@ -124,4 +124,4 @@ export const ChapterAccessForm = ({
             )}
         </div>
     );
-}
+};

--- a/app/(dashboard)/(routes)/teacher/courses/[courseId]/chapters/[chapterId]/_components/chapter-actions.tsx
+++ b/app/(dashboard)/(routes)/teacher/courses/[courseId]/chapters/[chapterId]/_components/chapter-actions.tsx
@@ -44,7 +44,7 @@ export const ChapterActions = ({
         } finally {
             setIsLoading(false);
         }
-    }
+    };
 
     const onDelete = async () => {
         try {
@@ -60,7 +60,7 @@ export const ChapterActions = ({
         } finally {
             setIsLoading(false);
         }
-    }
+    };
 
 
     return (
@@ -81,5 +81,5 @@ export const ChapterActions = ({
                 </Button>
             </ConfirmModal>
         </div>
-    )
-}
+    );
+};

--- a/app/(dashboard)/(routes)/teacher/courses/[courseId]/chapters/[chapterId]/_components/chapter-description-form.tsx
+++ b/app/(dashboard)/(routes)/teacher/courses/[courseId]/chapters/[chapterId]/_components/chapter-description-form.tsx
@@ -62,7 +62,7 @@ export const ChapterDescriptionForm = ({
         } catch {
             toast.error("Something went wrong");
         }
-    }
+    };
 
     return (
         <div className="mt-6 border bg-muted rounded-md p-4">
@@ -125,4 +125,4 @@ export const ChapterDescriptionForm = ({
             )}
         </div>
     );
-}
+};

--- a/app/(dashboard)/(routes)/teacher/courses/[courseId]/chapters/[chapterId]/_components/chapter-title-form.tsx
+++ b/app/(dashboard)/(routes)/teacher/courses/[courseId]/chapters/[chapterId]/_components/chapter-title-form.tsx
@@ -59,7 +59,7 @@ export const ChapterTitleForm = ({
         } catch {
             toast.error("Something went wrong");
         }
-    }
+    };
 
     return (
         <div className="mt-6 border bg-muted rounded-md p-4">
@@ -116,4 +116,4 @@ export const ChapterTitleForm = ({
             )}
         </div>
     );
-}
+};

--- a/app/(dashboard)/(routes)/teacher/courses/[courseId]/chapters/[chapterId]/_components/chapter-video-form.tsx
+++ b/app/(dashboard)/(routes)/teacher/courses/[courseId]/chapters/[chapterId]/_components/chapter-video-form.tsx
@@ -20,6 +20,11 @@ interface ChapterVideoFormProps {
     chapterId: string;
 };
 
+// Declared but never enforced: this form submits from a callback rather
+// than through zodResolver, so the schema only supplies a type. Left in
+// place rather than deleted -- the shape it documents is correct, and
+// wiring it up is a behaviour change that belongs with the form work.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const formSchema = z.object({
     videoUrl: z.string().min(1),
 });
@@ -44,7 +49,7 @@ export const ChapterVideoForm = ({
         } catch {
             toast.error("Something went wrong");
         }
-    }
+    };
 
     return (
         <div className="mt-6 border bg-muted rounded-md p-4">
@@ -103,5 +108,5 @@ export const ChapterVideoForm = ({
             )}
         </div>
     );
-}
+};
 

--- a/app/(dashboard)/(routes)/teacher/courses/[courseId]/chapters/[chapterId]/page.tsx
+++ b/app/(dashboard)/(routes)/teacher/courses/[courseId]/chapters/[chapterId]/page.tsx
@@ -21,7 +21,7 @@ const ChapterIdPAge = async ({
     const { courseId, chapterId } = await params;
 
 
-    const { userId } = await requirePagePrincipal("/dashboard");
+    await requirePagePrincipal("/dashboard");
     const chapter = await db.topic.findUnique({
         where: {
             id: chapterId,

--- a/app/(dashboard)/(routes)/teacher/courses/[courseId]/page.tsx
+++ b/app/(dashboard)/(routes)/teacher/courses/[courseId]/page.tsx
@@ -171,6 +171,6 @@ const CourseIdPage = async ({
             </div>
         </>
      );
-}
+};
  
 export default CourseIdPage;

--- a/app/(dashboard)/(routes)/teacher/courses/page.tsx
+++ b/app/(dashboard)/(routes)/teacher/courses/page.tsx
@@ -1,5 +1,4 @@
 import { requirePagePrincipal } from "@/lib/auth";
-import { redirect } from "next/navigation";
 
 import { db } from "@/lib/db";
 
@@ -23,6 +22,6 @@ const CoursesPage = async () => {
             <DataTable columns={columns} data={courses} />
         </PageContainer>
      );
-}
+};
  
 export default CoursesPage;

--- a/app/(dashboard)/(routes)/teacher/create/page.tsx
+++ b/app/(dashboard)/(routes)/teacher/create/page.tsx
@@ -47,7 +47,7 @@ const CreatePage = () => {
         } catch {
             toast.error("Something went wrong");
         }
-    }
+    };
 
     return ( 
         <div className="max-w-5xl mx-auto flex md:items-center md:justify-center h-full px-4 py-6 sm:p-6">
@@ -103,6 +103,6 @@ const CreatePage = () => {
             </div>
         </div>
      );
-}
+};
  
 export default CreatePage;

--- a/app/(dashboard)/_components/sidebar-item.tsx
+++ b/app/(dashboard)/_components/sidebar-item.tsx
@@ -31,7 +31,7 @@ export const SidebarItem = ({
 
     const onClick = () => {
         router.push(href);
-    }
+    };
 
     return (
         <button
@@ -53,5 +53,5 @@ export const SidebarItem = ({
             />
             {!collapsed && <span className="truncate">{label}</span>}
         </button>
-    )
-}
+    );
+};

--- a/app/api/courses/[courseId]/attachments/[attachmentId]/route.ts
+++ b/app/api/courses/[courseId]/attachments/[attachmentId]/route.ts
@@ -12,7 +12,6 @@ export async function DELETE(
     try {
         const principal = await requirePrincipal();
         await authorizeCourse(principal, "attachment:delete", routeParams.courseId);
-        const userId = principal.userId;
 
         const attachment = await db.attachment.delete({
             where: {

--- a/app/api/courses/[courseId]/attachments/route.ts
+++ b/app/api/courses/[courseId]/attachments/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server"
+import { NextResponse } from "next/server";
 
 import { db } from "@/lib/db";
 import { authorizeCourse, requirePrincipal, toResponse } from "@/lib/auth";
@@ -14,7 +14,6 @@ export async function POST(
     try {
         const principal = await requirePrincipal();
         await authorizeCourse(principal, "attachment:create", routeParams.courseId);
-        const userId = principal.userId;
         const { url } = await req.json();
 
         const attachment = await db.attachment.create({

--- a/app/api/courses/[courseId]/chapters/[chapterId]/unpublish/route.ts
+++ b/app/api/courses/[courseId]/chapters/[chapterId]/unpublish/route.ts
@@ -12,7 +12,6 @@ export async function PATCH(
     try {
         const principal = await requirePrincipal();
         await authorizeTopicInCourse(principal, "topic:update", routeParams.courseId, routeParams.chapterId);
-        const userId = principal.userId;
 
         const unpublishedTopic = await db.topic.update({
             where: {

--- a/app/api/courses/[courseId]/chapters/reorder/route.ts
+++ b/app/api/courses/[courseId]/chapters/reorder/route.ts
@@ -12,7 +12,6 @@ export async function PUT(
     try {
         const principal = await requirePrincipal();
         await authorizeCourse(principal, "topic:reorder", routeParams.courseId);
-        const userId = principal.userId;
 
         const { list } = await req.json();
 

--- a/app/api/uploadthing/core.ts
+++ b/app/api/uploadthing/core.ts
@@ -17,7 +17,7 @@ const handleAuth = async () => {
     }
 
     return { userId: principal.userId };
-}
+};
  
  
 export const ourFileRouter = {

--- a/components/admin/columns.tsx
+++ b/components/admin/columns.tsx
@@ -1,19 +1,19 @@
-"use client"
+"use client";
 
-import { Course } from "@prisma/client"
-import { ColumnDef } from "@tanstack/react-table"
-import { ArrowUpDown, MoreHorizontal, Pencil } from "lucide-react"
+import { Course } from "@prisma/client";
+import { ColumnDef } from "@tanstack/react-table";
+import { ArrowUpDown, MoreHorizontal, Pencil } from "lucide-react";
 
-import { Button } from "@/components/ui/button" 
+import { Button } from "@/components/ui/button"; 
 import {
     DropdownMenu,
     DropdownMenuContent,
     DropdownMenuItem,
     DropdownMenuTrigger
-} from "@/components/ui/dropdown-menu"
-import Link from "next/link"
-import { Badge } from "@/components/ui/badge"
-import { cn } from "@/lib/utils"
+} from "@/components/ui/dropdown-menu";
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
 
 export const columns: ColumnDef<Course>[] = [
   {
@@ -27,7 +27,7 @@ export const columns: ColumnDef<Course>[] = [
             Title
             <ArrowUpDown className="ml-2 h-4 w-4" />
         </Button>
-      )
+      );
     },
   },
   {
@@ -41,7 +41,7 @@ export const columns: ColumnDef<Course>[] = [
               Price
               <ArrowUpDown className="ml-2 h-4 w-4" />
           </Button>
-        )
+        );
     },
     cell: ({ row }) => {
         const price = parseFloat(row.getValue("price") || "0");
@@ -50,7 +50,7 @@ export const columns: ColumnDef<Course>[] = [
             currency: "USD",
         }).format(price);
 
-        return <div>{formatted}</div>
+        return <div>{formatted}</div>;
     }
   },
   {
@@ -64,7 +64,7 @@ export const columns: ColumnDef<Course>[] = [
               Published
               <ArrowUpDown className="ml-2 h-4 w-4" />
           </Button>
-        )
+        );
     },
     cell: ({ row }) => {
         const isPublished = row.getValue("isPublished") || false;
@@ -76,7 +76,7 @@ export const columns: ColumnDef<Course>[] = [
             )}>
                 {isPublished ? "Published" : "Draft"}
             </Badge>
-        )
+        );
     }
   },
   {
@@ -101,7 +101,7 @@ export const columns: ColumnDef<Course>[] = [
                     </Link>
                 </DropdownMenuContent>
             </DropdownMenu>
-        )
+        );
     }
   }
-]
+];

--- a/components/admin/data-card.tsx
+++ b/components/admin/data-card.tsx
@@ -30,5 +30,5 @@ export const DataCard = ({
                 </div>
             </CardContent>
         </Card>
-    )
-}
+    );
+};

--- a/components/admin/data-table.tsx
+++ b/components/admin/data-table.tsx
@@ -1,5 +1,5 @@
-"use client"
-import * as React from "react"
+"use client";
+import * as React from "react";
 
 import {
   ColumnDef,
@@ -11,7 +11,7 @@ import {
   getPaginationRowModel,
   getSortedRowModel,
   useReactTable,
-} from "@tanstack/react-table"
+} from "@tanstack/react-table";
 
 import {
   Table,
@@ -20,11 +20,11 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from "@/components/ui/table"
-import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import Link from "next/link"
-import { PlusCircle } from "lucide-react"
+} from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import Link from "next/link";
+import { PlusCircle } from "lucide-react";
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[]
@@ -35,8 +35,8 @@ export function DataTable<TData, TValue>({
   columns,
   data,
 }: DataTableProps<TData, TValue>) {
-    const [sorting, setSorting] = React.useState<SortingState>([])
-    const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([])
+    const [sorting, setSorting] = React.useState<SortingState>([]);
+    const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([]);
 
     const table = useReactTable({
         data,
@@ -51,7 +51,7 @@ export function DataTable<TData, TValue>({
             sorting,
             columnFilters,
         },
-    })
+    });
 
   return (
     <div>
@@ -86,7 +86,7 @@ export function DataTable<TData, TValue>({
                                 header.getContext()
                                 )}
                         </TableHead>
-                        )
+                        );
                     })}
                     </TableRow>
                 ))}
@@ -134,5 +134,5 @@ export function DataTable<TData, TValue>({
         </Button>
       </div>
     </div>
-  )
+  );
 }

--- a/components/banner.tsx
+++ b/components/banner.tsx
@@ -25,7 +25,7 @@ interface BannerProps extends VariantProps<typeof bannerVariants> {
 const iconMap = {
     warning: AlertTriangle,
     success: CheckCircleIcon,
-}
+};
 
 export const Banner = ({
     label,
@@ -38,5 +38,5 @@ export const Banner = ({
             <Icon className="h-4 w-4 mr-2" />
             {label}
         </div>
-    )
-}
+    );
+};

--- a/components/course-card.tsx
+++ b/components/course-card.tsx
@@ -64,5 +64,5 @@ export const CourseCard = ({
                 </div>
             </div>
         </Link>
-    )
-}
+    );
+};

--- a/components/course-progress.tsx
+++ b/components/course-progress.tsx
@@ -10,12 +10,12 @@ interface CourseProgressProps {
 const colorByVariant = {
     default: "text-akomapa-teal",
     success: "text-success",
-}
+};
 
 const sizeByVariant = {
     default: "text-sm",
     sm: "text-xs",
-}
+};
 
 export const CourseProgress = ({
     value,
@@ -37,5 +37,5 @@ export const CourseProgress = ({
                 {Math.round(value)}% complete
             </p>
         </div>
-    )
-} 
+    );
+}; 

--- a/components/courses-list.tsx
+++ b/components/courses-list.tsx
@@ -41,5 +41,5 @@ export const CoursesList = ({
                 </div>
             )}
         </div>
-    )
-}
+    );
+};

--- a/components/file-upload.tsx
+++ b/components/file-upload.tsx
@@ -24,5 +24,5 @@ export const FileUpload = ({
                 toast.error(`${error?.message}`);
             }}
         />
-    )
-}
+    );
+};

--- a/components/icon-badge.tsx
+++ b/components/icon-badge.tsx
@@ -59,5 +59,5 @@ export const IconBadge = ({
         <div className={cn(backgroundVariants({ variant, size }))}>
             <Icon className={cn(iconVariants({ variant, size }))} />
         </div>
-    )
+    );
 };

--- a/components/modals/confirm-modal.tsx
+++ b/components/modals/confirm-modal.tsx
@@ -43,5 +43,5 @@ export const ConfirmModal = ({
                 </AlertDialogFooter>
             </AlertDialogContent>
         </AlertDialog>
-    )
-}
+    );
+};

--- a/components/providers/confetti-provider.tsx
+++ b/components/providers/confetti-provider.tsx
@@ -18,5 +18,5 @@ export const ConfettiProvider = () => {
                 confetti.onClose();
             }}
         />
-    )
-}
+    );
+};

--- a/components/providers/toaster-provider.tsx
+++ b/components/providers/toaster-provider.tsx
@@ -3,5 +3,5 @@
 import { Toaster } from "react-hot-toast";
 
 export const ToastProvider = () => {
-    return <Toaster />
-}
+    return <Toaster />;
+};

--- a/components/search-input.tsx
+++ b/components/search-input.tsx
@@ -29,7 +29,7 @@ export const SearchInput = () => {
         }, { skipEmptyString: true, skipNull: true});
 
         router.push(url);
-    }, [debounceValue, currentCategoryId, router, pathname])
+    }, [debounceValue, currentCategoryId, router, pathname]);
 
     return (
         <div className="relative">
@@ -43,5 +43,5 @@ export const SearchInput = () => {
                 placeholder="Search for a course..."
             />
         </div>
-    )
-}
+    );
+};

--- a/components/ui/accordion.tsx
+++ b/components/ui/accordion.tsx
@@ -1,12 +1,12 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as AccordionPrimitive from "@radix-ui/react-accordion"
-import { ChevronDown } from "lucide-react"
+import * as React from "react";
+import * as AccordionPrimitive from "@radix-ui/react-accordion";
+import { ChevronDown } from "lucide-react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-const Accordion = AccordionPrimitive.Root
+const Accordion = AccordionPrimitive.Root;
 
 const AccordionItem = React.forwardRef<
   React.ElementRef<typeof AccordionPrimitive.Item>,
@@ -17,8 +17,8 @@ const AccordionItem = React.forwardRef<
     className={cn("border-b", className)}
     {...props}
   />
-))
-AccordionItem.displayName = "AccordionItem"
+));
+AccordionItem.displayName = "AccordionItem";
 
 const AccordionTrigger = React.forwardRef<
   React.ElementRef<typeof AccordionPrimitive.Trigger>,
@@ -37,8 +37,8 @@ const AccordionTrigger = React.forwardRef<
       <ChevronDown className="h-4 w-4 shrink-0 transition-transform duration-200" />
     </AccordionPrimitive.Trigger>
   </AccordionPrimitive.Header>
-))
-AccordionTrigger.displayName = AccordionPrimitive.Trigger.displayName
+));
+AccordionTrigger.displayName = AccordionPrimitive.Trigger.displayName;
 
 const AccordionContent = React.forwardRef<
   React.ElementRef<typeof AccordionPrimitive.Content>,
@@ -51,8 +51,8 @@ const AccordionContent = React.forwardRef<
   >
     <div className={cn("pb-4 pt-0", className)}>{children}</div>
   </AccordionPrimitive.Content>
-))
+));
 
-AccordionContent.displayName = AccordionPrimitive.Content.displayName
+AccordionContent.displayName = AccordionPrimitive.Content.displayName;
 
-export { Accordion, AccordionItem, AccordionTrigger, AccordionContent }
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent };

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -1,16 +1,16 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+import * as React from "react";
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
 
-import { cn } from "@/lib/utils"
-import { buttonVariants } from "@/components/ui/button"
+import { cn } from "@/lib/utils";
+import { buttonVariants } from "@/components/ui/button";
 
-const AlertDialog = AlertDialogPrimitive.Root
+const AlertDialog = AlertDialogPrimitive.Root;
 
-const AlertDialogTrigger = AlertDialogPrimitive.Trigger
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
 
-const AlertDialogPortal = AlertDialogPrimitive.Portal
+const AlertDialogPortal = AlertDialogPrimitive.Portal;
 
 const AlertDialogOverlay = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
@@ -24,8 +24,8 @@ const AlertDialogOverlay = React.forwardRef<
     {...props}
     ref={ref}
   />
-))
-AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName
+));
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName;
 
 const AlertDialogContent = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Content>,
@@ -42,8 +42,8 @@ const AlertDialogContent = React.forwardRef<
       {...props}
     />
   </AlertDialogPortal>
-))
-AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName
+));
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;
 
 const AlertDialogHeader = ({
   className,
@@ -56,8 +56,8 @@ const AlertDialogHeader = ({
     )}
     {...props}
   />
-)
-AlertDialogHeader.displayName = "AlertDialogHeader"
+);
+AlertDialogHeader.displayName = "AlertDialogHeader";
 
 const AlertDialogFooter = ({
   className,
@@ -70,8 +70,8 @@ const AlertDialogFooter = ({
     )}
     {...props}
   />
-)
-AlertDialogFooter.displayName = "AlertDialogFooter"
+);
+AlertDialogFooter.displayName = "AlertDialogFooter";
 
 const AlertDialogTitle = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Title>,
@@ -82,8 +82,8 @@ const AlertDialogTitle = React.forwardRef<
     className={cn("text-lg font-semibold", className)}
     {...props}
   />
-))
-AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName
+));
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName;
 
 const AlertDialogDescription = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Description>,
@@ -94,9 +94,9 @@ const AlertDialogDescription = React.forwardRef<
     className={cn("text-sm text-muted-foreground", className)}
     {...props}
   />
-))
+));
 AlertDialogDescription.displayName =
-  AlertDialogPrimitive.Description.displayName
+  AlertDialogPrimitive.Description.displayName;
 
 const AlertDialogAction = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Action>,
@@ -107,8 +107,8 @@ const AlertDialogAction = React.forwardRef<
     className={cn(buttonVariants(), className)}
     {...props}
   />
-))
-AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName
+));
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName;
 
 const AlertDialogCancel = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
@@ -123,8 +123,8 @@ const AlertDialogCancel = React.forwardRef<
     )}
     {...props}
   />
-))
-AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName
+));
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName;
 
 export {
   AlertDialog,
@@ -138,4 +138,4 @@ export {
   AlertDialogDescription,
   AlertDialogAction,
   AlertDialogCancel,
-}
+};

--- a/components/ui/avatar.tsx
+++ b/components/ui/avatar.tsx
@@ -1,9 +1,9 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as AvatarPrimitive from "@radix-ui/react-avatar"
+import * as React from "react";
+import * as AvatarPrimitive from "@radix-ui/react-avatar";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const Avatar = React.forwardRef<
   React.ElementRef<typeof AvatarPrimitive.Root>,
@@ -17,8 +17,8 @@ const Avatar = React.forwardRef<
     )}
     {...props}
   />
-))
-Avatar.displayName = AvatarPrimitive.Root.displayName
+));
+Avatar.displayName = AvatarPrimitive.Root.displayName;
 
 const AvatarImage = React.forwardRef<
   React.ElementRef<typeof AvatarPrimitive.Image>,
@@ -29,8 +29,8 @@ const AvatarImage = React.forwardRef<
     className={cn("aspect-square h-full w-full", className)}
     {...props}
   />
-))
-AvatarImage.displayName = AvatarPrimitive.Image.displayName
+));
+AvatarImage.displayName = AvatarPrimitive.Image.displayName;
 
 const AvatarFallback = React.forwardRef<
   React.ElementRef<typeof AvatarPrimitive.Fallback>,
@@ -44,7 +44,7 @@ const AvatarFallback = React.forwardRef<
     )}
     {...props}
   />
-))
-AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName
+));
+AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName;
 
-export { Avatar, AvatarImage, AvatarFallback }
+export { Avatar, AvatarImage, AvatarFallback };

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,7 +1,7 @@
-import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
   "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
@@ -21,7 +21,7 @@ const badgeVariants = cva(
       variant: "default",
     },
   }
-)
+);
 
 export interface BadgeProps
   extends React.HTMLAttributes<HTMLDivElement>,
@@ -30,7 +30,7 @@ export interface BadgeProps
 function Badge({ className, variant, ...props }: BadgeProps) {
   return (
     <div className={cn(badgeVariants({ variant }), className)} {...props} />
-  )
+  );
 }
 
-export { Badge, badgeVariants }
+export { Badge, badgeVariants };

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,8 +1,8 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
@@ -32,7 +32,7 @@ const buttonVariants = cva(
       size: "default",
     },
   }
-)
+);
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
@@ -42,16 +42,16 @@ export interface ButtonProps
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : "button"
+    const Comp = asChild ? Slot : "button";
     return (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
         {...props}
       />
-    )
+    );
   }
-)
-Button.displayName = "Button"
+);
+Button.displayName = "Button";
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
+import * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const Card = React.forwardRef<
   HTMLDivElement,
@@ -14,8 +14,8 @@ const Card = React.forwardRef<
     )}
     {...props}
   />
-))
-Card.displayName = "Card"
+));
+Card.displayName = "Card";
 
 const CardHeader = React.forwardRef<
   HTMLDivElement,
@@ -26,8 +26,8 @@ const CardHeader = React.forwardRef<
     className={cn("flex flex-col space-y-1.5 p-6", className)}
     {...props}
   />
-))
-CardHeader.displayName = "CardHeader"
+));
+CardHeader.displayName = "CardHeader";
 
 const CardTitle = React.forwardRef<
   HTMLParagraphElement,
@@ -41,8 +41,8 @@ const CardTitle = React.forwardRef<
     )}
     {...props}
   />
-))
-CardTitle.displayName = "CardTitle"
+));
+CardTitle.displayName = "CardTitle";
 
 const CardDescription = React.forwardRef<
   HTMLParagraphElement,
@@ -53,16 +53,16 @@ const CardDescription = React.forwardRef<
     className={cn("text-sm text-muted-foreground", className)}
     {...props}
   />
-))
-CardDescription.displayName = "CardDescription"
+));
+CardDescription.displayName = "CardDescription";
 
 const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
   <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
-))
-CardContent.displayName = "CardContent"
+));
+CardContent.displayName = "CardContent";
 
 const CardFooter = React.forwardRef<
   HTMLDivElement,
@@ -73,7 +73,7 @@ const CardFooter = React.forwardRef<
     className={cn("flex items-center p-6 pt-0", className)}
     {...props}
   />
-))
-CardFooter.displayName = "CardFooter"
+));
+CardFooter.displayName = "CardFooter";
 
-export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -1,10 +1,10 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
-import { Check } from "lucide-react"
+import * as React from "react";
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
+import { Check } from "lucide-react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const Checkbox = React.forwardRef<
   React.ElementRef<typeof CheckboxPrimitive.Root>,
@@ -24,7 +24,7 @@ const Checkbox = React.forwardRef<
       <Check className="h-4 w-4" />
     </CheckboxPrimitive.Indicator>
   </CheckboxPrimitive.Root>
-))
-Checkbox.displayName = CheckboxPrimitive.Root.displayName
+));
+Checkbox.displayName = CheckboxPrimitive.Root.displayName;
 
-export { Checkbox }
+export { Checkbox };

--- a/components/ui/combobox.tsx
+++ b/components/ui/combobox.tsx
@@ -1,16 +1,16 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import { Check, ChevronsUpDown } from "lucide-react"
+import * as React from "react";
+import { Check, ChevronsUpDown } from "lucide-react";
 
-import { cn } from "@/lib/utils"
-import { Button } from "@/components/ui/button"
-import { Command, CommandEmpty, CommandInput, CommandItem, CommandList } from "@/components/ui/command"
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Command, CommandEmpty, CommandInput, CommandItem, CommandList } from "@/components/ui/command";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
-} from "@/components/ui/popover"
+} from "@/components/ui/popover";
 
 interface ComboboxProps {
   options: { label: string; value: string }[];
@@ -23,7 +23,7 @@ export const Combobox = ({
   value,
   onChange,
 }: ComboboxProps) => {
-  const [open, setOpen] = React.useState(false)
+  const [open, setOpen] = React.useState(false);
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -49,8 +49,8 @@ export const Combobox = ({
               <CommandItem
                 key={option.value}
                 onSelect={() => {
-                  onChange(option.value === value ? "" : option.value)
-                  setOpen(false)
+                  onChange(option.value === value ? "" : option.value);
+                  setOpen(false);
                 }}
               >
                 <Check
@@ -66,5 +66,5 @@ export const Combobox = ({
         </Command>
       </PopoverContent>
     </Popover>
-  )
-}
+  );
+};

--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -1,12 +1,12 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import { type DialogProps } from "@radix-ui/react-dialog"
-import { Command as CommandPrimitive } from "cmdk"
-import { Search } from "lucide-react"
+import * as React from "react";
+import { type DialogProps } from "@radix-ui/react-dialog";
+import { Command as CommandPrimitive } from "cmdk";
+import { Search } from "lucide-react";
 
-import { cn } from "@/lib/utils"
-import { Dialog, DialogContent } from "@/components/ui/dialog"
+import { cn } from "@/lib/utils";
+import { Dialog, DialogContent } from "@/components/ui/dialog";
 
 const Command = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive>,
@@ -20,8 +20,8 @@ const Command = React.forwardRef<
     )}
     {...props}
   />
-))
-Command.displayName = CommandPrimitive.displayName
+));
+Command.displayName = CommandPrimitive.displayName;
 
 interface CommandDialogProps extends DialogProps {}
 
@@ -34,8 +34,8 @@ const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
         </Command>
       </DialogContent>
     </Dialog>
-  )
-}
+  );
+};
 
 const CommandInput = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Input>,
@@ -52,9 +52,9 @@ const CommandInput = React.forwardRef<
       {...props}
     />
   </div>
-))
+));
 
-CommandInput.displayName = CommandPrimitive.Input.displayName
+CommandInput.displayName = CommandPrimitive.Input.displayName;
 
 const CommandList = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.List>,
@@ -65,9 +65,9 @@ const CommandList = React.forwardRef<
     className={cn("max-h-[300px] overflow-y-auto overflow-x-hidden", className)}
     {...props}
   />
-))
+));
 
-CommandList.displayName = CommandPrimitive.List.displayName
+CommandList.displayName = CommandPrimitive.List.displayName;
 
 const CommandEmpty = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Empty>,
@@ -78,9 +78,9 @@ const CommandEmpty = React.forwardRef<
     className="py-6 text-center text-sm"
     {...props}
   />
-))
+));
 
-CommandEmpty.displayName = CommandPrimitive.Empty.displayName
+CommandEmpty.displayName = CommandPrimitive.Empty.displayName;
 
 const CommandGroup = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Group>,
@@ -94,9 +94,9 @@ const CommandGroup = React.forwardRef<
     )}
     {...props}
   />
-))
+));
 
-CommandGroup.displayName = CommandPrimitive.Group.displayName
+CommandGroup.displayName = CommandPrimitive.Group.displayName;
 
 const CommandSeparator = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Separator>,
@@ -107,8 +107,8 @@ const CommandSeparator = React.forwardRef<
     className={cn("-mx-1 h-px bg-border", className)}
     {...props}
   />
-))
-CommandSeparator.displayName = CommandPrimitive.Separator.displayName
+));
+CommandSeparator.displayName = CommandPrimitive.Separator.displayName;
 
 const CommandItem = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Item>,
@@ -122,9 +122,9 @@ const CommandItem = React.forwardRef<
     )}
     {...props}
   />
-))
+));
 
-CommandItem.displayName = CommandPrimitive.Item.displayName
+CommandItem.displayName = CommandPrimitive.Item.displayName;
 
 const CommandShortcut = ({
   className,
@@ -138,9 +138,9 @@ const CommandShortcut = ({
       )}
       {...props}
     />
-  )
-}
-CommandShortcut.displayName = "CommandShortcut"
+  );
+};
+CommandShortcut.displayName = "CommandShortcut";
 
 export {
   Command,
@@ -152,4 +152,4 @@ export {
   CommandItem,
   CommandShortcut,
   CommandSeparator,
-}
+};

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,18 +1,18 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as DialogPrimitive from "@radix-ui/react-dialog"
-import { X } from "lucide-react"
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-const Dialog = DialogPrimitive.Root
+const Dialog = DialogPrimitive.Root;
 
-const DialogTrigger = DialogPrimitive.Trigger
+const DialogTrigger = DialogPrimitive.Trigger;
 
-const DialogPortal = DialogPrimitive.Portal
+const DialogPortal = DialogPrimitive.Portal;
 
-const DialogClose = DialogPrimitive.Close
+const DialogClose = DialogPrimitive.Close;
 
 const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
@@ -26,8 +26,8 @@ const DialogOverlay = React.forwardRef<
     )}
     {...props}
   />
-))
-DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
@@ -50,8 +50,8 @@ const DialogContent = React.forwardRef<
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>
-))
-DialogContent.displayName = DialogPrimitive.Content.displayName
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
 
 const DialogHeader = ({
   className,
@@ -64,8 +64,8 @@ const DialogHeader = ({
     )}
     {...props}
   />
-)
-DialogHeader.displayName = "DialogHeader"
+);
+DialogHeader.displayName = "DialogHeader";
 
 const DialogFooter = ({
   className,
@@ -78,8 +78,8 @@ const DialogFooter = ({
     )}
     {...props}
   />
-)
-DialogFooter.displayName = "DialogFooter"
+);
+DialogFooter.displayName = "DialogFooter";
 
 const DialogTitle = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Title>,
@@ -93,8 +93,8 @@ const DialogTitle = React.forwardRef<
     )}
     {...props}
   />
-))
-DialogTitle.displayName = DialogPrimitive.Title.displayName
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
 
 const DialogDescription = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Description>,
@@ -105,8 +105,8 @@ const DialogDescription = React.forwardRef<
     className={cn("text-sm text-muted-foreground", className)}
     {...props}
   />
-))
-DialogDescription.displayName = DialogPrimitive.Description.displayName
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
 
 export {
   Dialog,
@@ -119,4 +119,4 @@ export {
   DialogFooter,
   DialogTitle,
   DialogDescription,
-}
+};

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -1,22 +1,22 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
-import { Check, ChevronRight, Circle } from "lucide-react"
+import * as React from "react";
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { Check, ChevronRight, Circle } from "lucide-react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-const DropdownMenu = DropdownMenuPrimitive.Root
+const DropdownMenu = DropdownMenuPrimitive.Root;
 
-const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
 
-const DropdownMenuGroup = DropdownMenuPrimitive.Group
+const DropdownMenuGroup = DropdownMenuPrimitive.Group;
 
-const DropdownMenuPortal = DropdownMenuPrimitive.Portal
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal;
 
-const DropdownMenuSub = DropdownMenuPrimitive.Sub
+const DropdownMenuSub = DropdownMenuPrimitive.Sub;
 
-const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup
+const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
 
 const DropdownMenuSubTrigger = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
@@ -36,9 +36,9 @@ const DropdownMenuSubTrigger = React.forwardRef<
     {children}
     <ChevronRight className="ml-auto h-4 w-4" />
   </DropdownMenuPrimitive.SubTrigger>
-))
+));
 DropdownMenuSubTrigger.displayName =
-  DropdownMenuPrimitive.SubTrigger.displayName
+  DropdownMenuPrimitive.SubTrigger.displayName;
 
 const DropdownMenuSubContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
@@ -52,9 +52,9 @@ const DropdownMenuSubContent = React.forwardRef<
     )}
     {...props}
   />
-))
+));
 DropdownMenuSubContent.displayName =
-  DropdownMenuPrimitive.SubContent.displayName
+  DropdownMenuPrimitive.SubContent.displayName;
 
 const DropdownMenuContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Content>,
@@ -71,8 +71,8 @@ const DropdownMenuContent = React.forwardRef<
       {...props}
     />
   </DropdownMenuPrimitive.Portal>
-))
-DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
+));
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
 
 const DropdownMenuItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Item>,
@@ -89,8 +89,8 @@ const DropdownMenuItem = React.forwardRef<
     )}
     {...props}
   />
-))
-DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
+));
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
 
 const DropdownMenuCheckboxItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
@@ -112,9 +112,9 @@ const DropdownMenuCheckboxItem = React.forwardRef<
     </span>
     {children}
   </DropdownMenuPrimitive.CheckboxItem>
-))
+));
 DropdownMenuCheckboxItem.displayName =
-  DropdownMenuPrimitive.CheckboxItem.displayName
+  DropdownMenuPrimitive.CheckboxItem.displayName;
 
 const DropdownMenuRadioItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
@@ -135,8 +135,8 @@ const DropdownMenuRadioItem = React.forwardRef<
     </span>
     {children}
   </DropdownMenuPrimitive.RadioItem>
-))
-DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName
+));
+DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName;
 
 const DropdownMenuLabel = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Label>,
@@ -153,8 +153,8 @@ const DropdownMenuLabel = React.forwardRef<
     )}
     {...props}
   />
-))
-DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName
+));
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
 
 const DropdownMenuSeparator = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
@@ -165,8 +165,8 @@ const DropdownMenuSeparator = React.forwardRef<
     className={cn("-mx-1 my-1 h-px bg-muted", className)}
     {...props}
   />
-))
-DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName
+));
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
 
 const DropdownMenuShortcut = ({
   className,
@@ -177,9 +177,9 @@ const DropdownMenuShortcut = ({
       className={cn("ml-auto text-xs tracking-widest opacity-60", className)}
       {...props}
     />
-  )
-}
-DropdownMenuShortcut.displayName = "DropdownMenuShortcut"
+  );
+};
+DropdownMenuShortcut.displayName = "DropdownMenuShortcut";
 
 export {
   DropdownMenu,
@@ -197,4 +197,4 @@ export {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuRadioGroup,
-}
+};

--- a/components/ui/form.tsx
+++ b/components/ui/form.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
-import * as LabelPrimitive from "@radix-ui/react-label"
-import { Slot } from "@radix-ui/react-slot"
+import * as React from "react";
+import * as LabelPrimitive from "@radix-ui/react-label";
+import { Slot } from "@radix-ui/react-slot";
 import {
   Controller,
   ControllerProps,
@@ -8,12 +8,12 @@ import {
   FieldValues,
   FormProvider,
   useFormContext,
-} from "react-hook-form"
+} from "react-hook-form";
 
-import { cn } from "@/lib/utils"
-import { Label } from "@/components/ui/label"
+import { cn } from "@/lib/utils";
+import { Label } from "@/components/ui/label";
 
-const Form = FormProvider
+const Form = FormProvider;
 
 type FormFieldContextValue<
   TFieldValues extends FieldValues = FieldValues,
@@ -24,7 +24,7 @@ type FormFieldContextValue<
 
 const FormFieldContext = React.createContext<FormFieldContextValue>(
   {} as FormFieldContextValue
-)
+);
 
 const FormField = <
   TFieldValues extends FieldValues = FieldValues,
@@ -36,21 +36,21 @@ const FormField = <
     <FormFieldContext.Provider value={{ name: props.name }}>
       <Controller {...props} />
     </FormFieldContext.Provider>
-  )
-}
+  );
+};
 
 const useFormField = () => {
-  const fieldContext = React.useContext(FormFieldContext)
-  const itemContext = React.useContext(FormItemContext)
-  const { getFieldState, formState } = useFormContext()
+  const fieldContext = React.useContext(FormFieldContext);
+  const itemContext = React.useContext(FormItemContext);
+  const { getFieldState, formState } = useFormContext();
 
-  const fieldState = getFieldState(fieldContext.name, formState)
+  const fieldState = getFieldState(fieldContext.name, formState);
 
   if (!fieldContext) {
-    throw new Error("useFormField should be used within <FormField>")
+    throw new Error("useFormField should be used within <FormField>");
   }
 
-  const { id } = itemContext
+  const { id } = itemContext;
 
   return {
     id,
@@ -59,8 +59,8 @@ const useFormField = () => {
     formDescriptionId: `${id}-form-item-description`,
     formMessageId: `${id}-form-item-message`,
     ...fieldState,
-  }
-}
+  };
+};
 
 type FormItemContextValue = {
   id: string
@@ -68,27 +68,27 @@ type FormItemContextValue = {
 
 const FormItemContext = React.createContext<FormItemContextValue>(
   {} as FormItemContextValue
-)
+);
 
 const FormItem = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => {
-  const id = React.useId()
+  const id = React.useId();
 
   return (
     <FormItemContext.Provider value={{ id }}>
       <div ref={ref} className={cn("space-y-2", className)} {...props} />
     </FormItemContext.Provider>
-  )
-})
-FormItem.displayName = "FormItem"
+  );
+});
+FormItem.displayName = "FormItem";
 
 const FormLabel = React.forwardRef<
   React.ElementRef<typeof LabelPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
 >(({ className, ...props }, ref) => {
-  const { error, formItemId } = useFormField()
+  const { error, formItemId } = useFormField();
 
   return (
     <Label
@@ -97,15 +97,15 @@ const FormLabel = React.forwardRef<
       htmlFor={formItemId}
       {...props}
     />
-  )
-})
-FormLabel.displayName = "FormLabel"
+  );
+});
+FormLabel.displayName = "FormLabel";
 
 const FormControl = React.forwardRef<
   React.ElementRef<typeof Slot>,
   React.ComponentPropsWithoutRef<typeof Slot>
 >(({ ...props }, ref) => {
-  const { error, formItemId, formDescriptionId, formMessageId } = useFormField()
+  const { error, formItemId, formDescriptionId, formMessageId } = useFormField();
 
   return (
     <Slot
@@ -119,15 +119,15 @@ const FormControl = React.forwardRef<
       aria-invalid={!!error}
       {...props}
     />
-  )
-})
-FormControl.displayName = "FormControl"
+  );
+});
+FormControl.displayName = "FormControl";
 
 const FormDescription = React.forwardRef<
   HTMLParagraphElement,
   React.HTMLAttributes<HTMLParagraphElement>
 >(({ className, ...props }, ref) => {
-  const { formDescriptionId } = useFormField()
+  const { formDescriptionId } = useFormField();
 
   return (
     <p
@@ -136,19 +136,19 @@ const FormDescription = React.forwardRef<
       className={cn("text-sm text-muted-foreground", className)}
       {...props}
     />
-  )
-})
-FormDescription.displayName = "FormDescription"
+  );
+});
+FormDescription.displayName = "FormDescription";
 
 const FormMessage = React.forwardRef<
   HTMLParagraphElement,
   React.HTMLAttributes<HTMLParagraphElement>
 >(({ className, children, ...props }, ref) => {
-  const { error, formMessageId } = useFormField()
-  const body = error ? String(error?.message) : children
+  const { error, formMessageId } = useFormField();
+  const body = error ? String(error?.message) : children;
 
   if (!body) {
-    return null
+    return null;
   }
 
   return (
@@ -160,9 +160,9 @@ const FormMessage = React.forwardRef<
     >
       {body}
     </p>
-  )
-})
-FormMessage.displayName = "FormMessage"
+  );
+});
+FormMessage.displayName = "FormMessage";
 
 export {
   useFormField,
@@ -173,4 +173,4 @@ export {
   FormDescription,
   FormMessage,
   FormField,
-}
+};

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
+import * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 export interface InputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {}
@@ -17,9 +17,9 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
         ref={ref}
         {...props}
       />
-    )
+    );
   }
-)
-Input.displayName = "Input"
+);
+Input.displayName = "Input";
 
-export { Input }
+export { Input };

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,14 +1,14 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as LabelPrimitive from "@radix-ui/react-label"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react";
+import * as LabelPrimitive from "@radix-ui/react-label";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const labelVariants = cva(
   "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-)
+);
 
 const Label = React.forwardRef<
   React.ElementRef<typeof LabelPrimitive.Root>,
@@ -20,7 +20,7 @@ const Label = React.forwardRef<
     className={cn(labelVariants(), className)}
     {...props}
   />
-))
-Label.displayName = LabelPrimitive.Root.displayName
+));
+Label.displayName = LabelPrimitive.Root.displayName;
 
-export { Label }
+export { Label };

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -1,13 +1,13 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as PopoverPrimitive from "@radix-ui/react-popover"
+import * as React from "react";
+import * as PopoverPrimitive from "@radix-ui/react-popover";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-const Popover = PopoverPrimitive.Root
+const Popover = PopoverPrimitive.Root;
 
-const PopoverTrigger = PopoverPrimitive.Trigger
+const PopoverTrigger = PopoverPrimitive.Trigger;
 
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
@@ -25,7 +25,7 @@ const PopoverContent = React.forwardRef<
       {...props}
     />
   </PopoverPrimitive.Portal>
-))
-PopoverContent.displayName = PopoverPrimitive.Content.displayName
+));
+PopoverContent.displayName = PopoverPrimitive.Content.displayName;
 
-export { Popover, PopoverTrigger, PopoverContent }
+export { Popover, PopoverTrigger, PopoverContent };

--- a/components/ui/progress.tsx
+++ b/components/ui/progress.tsx
@@ -1,10 +1,10 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as ProgressPrimitive from "@radix-ui/react-progress"
+import * as React from "react";
+import * as ProgressPrimitive from "@radix-ui/react-progress";
 
-import { cn } from "@/lib/utils"
-import { cva, type VariantProps } from "class-variance-authority"
+import { cn } from "@/lib/utils";
+import { cva, type VariantProps } from "class-variance-authority";
 
 const progressVariants = cva(
   "h-full w-full flex-1 bg-primary transition-all",
@@ -19,7 +19,7 @@ const progressVariants = cva(
       variant: "default"
     }
   }
-)
+);
 
 export interface ProgressProps
   extends React.HTMLAttributes<HTMLDivElement>,
@@ -44,7 +44,7 @@ const Progress = React.forwardRef<
       style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
     />
   </ProgressPrimitive.Root>
-))
-Progress.displayName = ProgressPrimitive.Root.displayName
+));
+Progress.displayName = ProgressPrimitive.Root.displayName;
 
-export { Progress }
+export { Progress };

--- a/components/ui/radio-group.tsx
+++ b/components/ui/radio-group.tsx
@@ -1,10 +1,10 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as RadioGroupPrimitive from "@radix-ui/react-radio-group"
-import { Circle } from "lucide-react"
+import * as React from "react";
+import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
+import { Circle } from "lucide-react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const RadioGroup = React.forwardRef<
   React.ElementRef<typeof RadioGroupPrimitive.Root>,
@@ -16,9 +16,9 @@ const RadioGroup = React.forwardRef<
       {...props}
       ref={ref}
     />
-  )
-})
-RadioGroup.displayName = RadioGroupPrimitive.Root.displayName
+  );
+});
+RadioGroup.displayName = RadioGroupPrimitive.Root.displayName;
 
 const RadioGroupItem = React.forwardRef<
   React.ElementRef<typeof RadioGroupPrimitive.Item>,
@@ -37,8 +37,8 @@ const RadioGroupItem = React.forwardRef<
         <Circle className="h-2.5 w-2.5 fill-current text-current" />
       </RadioGroupPrimitive.Indicator>
     </RadioGroupPrimitive.Item>
-  )
-})
-RadioGroupItem.displayName = RadioGroupPrimitive.Item.displayName
+  );
+});
+RadioGroupItem.displayName = RadioGroupPrimitive.Item.displayName;
 
-export { RadioGroup, RadioGroupItem }
+export { RadioGroup, RadioGroupItem };

--- a/components/ui/scroll-area.tsx
+++ b/components/ui/scroll-area.tsx
@@ -1,9 +1,9 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
+import * as React from "react";
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const ScrollArea = React.forwardRef<
   React.ElementRef<typeof ScrollAreaPrimitive.Root>,
@@ -20,8 +20,8 @@ const ScrollArea = React.forwardRef<
     <ScrollBar />
     <ScrollAreaPrimitive.Corner />
   </ScrollAreaPrimitive.Root>
-))
-ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName
+));
+ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName;
 
 const ScrollBar = React.forwardRef<
   React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
@@ -42,7 +42,7 @@ const ScrollBar = React.forwardRef<
   >
     <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
   </ScrollAreaPrimitive.ScrollAreaScrollbar>
-))
-ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName
+));
+ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName;
 
-export { ScrollArea, ScrollBar }
+export { ScrollArea, ScrollBar };

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -1,16 +1,16 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as SelectPrimitive from "@radix-ui/react-select"
-import { Check, ChevronDown, ChevronUp } from "lucide-react"
+import * as React from "react";
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { Check, ChevronDown, ChevronUp } from "lucide-react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-const Select = SelectPrimitive.Root
+const Select = SelectPrimitive.Root;
 
-const SelectGroup = SelectPrimitive.Group
+const SelectGroup = SelectPrimitive.Group;
 
-const SelectValue = SelectPrimitive.Value
+const SelectValue = SelectPrimitive.Value;
 
 const SelectTrigger = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Trigger>,
@@ -29,8 +29,8 @@ const SelectTrigger = React.forwardRef<
       <ChevronDown className="h-4 w-4 opacity-50" />
     </SelectPrimitive.Icon>
   </SelectPrimitive.Trigger>
-))
-SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
+));
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
 
 const SelectScrollUpButton = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
@@ -46,8 +46,8 @@ const SelectScrollUpButton = React.forwardRef<
   >
     <ChevronUp className="h-4 w-4" />
   </SelectPrimitive.ScrollUpButton>
-))
-SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName
+));
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
 
 const SelectScrollDownButton = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
@@ -63,9 +63,9 @@ const SelectScrollDownButton = React.forwardRef<
   >
     <ChevronDown className="h-4 w-4" />
   </SelectPrimitive.ScrollDownButton>
-))
+));
 SelectScrollDownButton.displayName =
-  SelectPrimitive.ScrollDownButton.displayName
+  SelectPrimitive.ScrollDownButton.displayName;
 
 const SelectContent = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Content>,
@@ -96,8 +96,8 @@ const SelectContent = React.forwardRef<
       <SelectScrollDownButton />
     </SelectPrimitive.Content>
   </SelectPrimitive.Portal>
-))
-SelectContent.displayName = SelectPrimitive.Content.displayName
+));
+SelectContent.displayName = SelectPrimitive.Content.displayName;
 
 const SelectLabel = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Label>,
@@ -108,8 +108,8 @@ const SelectLabel = React.forwardRef<
     className={cn("py-1.5 pl-8 pr-2 text-sm font-semibold", className)}
     {...props}
   />
-))
-SelectLabel.displayName = SelectPrimitive.Label.displayName
+));
+SelectLabel.displayName = SelectPrimitive.Label.displayName;
 
 const SelectItem = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Item>,
@@ -131,8 +131,8 @@ const SelectItem = React.forwardRef<
 
     <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
   </SelectPrimitive.Item>
-))
-SelectItem.displayName = SelectPrimitive.Item.displayName
+));
+SelectItem.displayName = SelectPrimitive.Item.displayName;
 
 const SelectSeparator = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Separator>,
@@ -143,8 +143,8 @@ const SelectSeparator = React.forwardRef<
     className={cn("-mx-1 my-1 h-px bg-muted", className)}
     {...props}
   />
-))
-SelectSeparator.displayName = SelectPrimitive.Separator.displayName
+));
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
 
 export {
   Select,
@@ -157,4 +157,4 @@ export {
   SelectSeparator,
   SelectScrollUpButton,
   SelectScrollDownButton,
-}
+};

--- a/components/ui/separator.tsx
+++ b/components/ui/separator.tsx
@@ -1,9 +1,9 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as SeparatorPrimitive from "@radix-ui/react-separator"
+import * as React from "react";
+import * as SeparatorPrimitive from "@radix-ui/react-separator";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const Separator = React.forwardRef<
   React.ElementRef<typeof SeparatorPrimitive.Root>,
@@ -25,7 +25,7 @@ const Separator = React.forwardRef<
       {...props}
     />
   )
-)
-Separator.displayName = SeparatorPrimitive.Root.displayName
+);
+Separator.displayName = SeparatorPrimitive.Root.displayName;
 
-export { Separator }
+export { Separator };

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -1,19 +1,19 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as SheetPrimitive from "@radix-ui/react-dialog"
-import { cva, type VariantProps } from "class-variance-authority"
-import { X } from "lucide-react"
+import * as React from "react";
+import * as SheetPrimitive from "@radix-ui/react-dialog";
+import { cva, type VariantProps } from "class-variance-authority";
+import { X } from "lucide-react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-const Sheet = SheetPrimitive.Root
+const Sheet = SheetPrimitive.Root;
 
-const SheetTrigger = SheetPrimitive.Trigger
+const SheetTrigger = SheetPrimitive.Trigger;
 
-const SheetClose = SheetPrimitive.Close
+const SheetClose = SheetPrimitive.Close;
 
-const SheetPortal = SheetPrimitive.Portal
+const SheetPortal = SheetPrimitive.Portal;
 
 const SheetOverlay = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Overlay>,
@@ -27,8 +27,8 @@ const SheetOverlay = React.forwardRef<
     {...props}
     ref={ref}
   />
-))
-SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
+));
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
 
 const sheetVariants = cva(
   "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
@@ -47,7 +47,7 @@ const sheetVariants = cva(
       side: "right",
     },
   }
-)
+);
 
 interface SheetContentProps
   extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
@@ -75,8 +75,8 @@ const SheetContent = React.forwardRef<
       </SheetPrimitive.Close>
     </SheetPrimitive.Content>
   </SheetPortal>
-))
-SheetContent.displayName = SheetPrimitive.Content.displayName
+));
+SheetContent.displayName = SheetPrimitive.Content.displayName;
 
 const SheetHeader = ({
   className,
@@ -89,8 +89,8 @@ const SheetHeader = ({
     )}
     {...props}
   />
-)
-SheetHeader.displayName = "SheetHeader"
+);
+SheetHeader.displayName = "SheetHeader";
 
 const SheetFooter = ({
   className,
@@ -103,8 +103,8 @@ const SheetFooter = ({
     )}
     {...props}
   />
-)
-SheetFooter.displayName = "SheetFooter"
+);
+SheetFooter.displayName = "SheetFooter";
 
 const SheetTitle = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Title>,
@@ -115,8 +115,8 @@ const SheetTitle = React.forwardRef<
     className={cn("text-lg font-semibold text-foreground", className)}
     {...props}
   />
-))
-SheetTitle.displayName = SheetPrimitive.Title.displayName
+));
+SheetTitle.displayName = SheetPrimitive.Title.displayName;
 
 const SheetDescription = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Description>,
@@ -127,8 +127,8 @@ const SheetDescription = React.forwardRef<
     className={cn("text-sm text-muted-foreground", className)}
     {...props}
   />
-))
-SheetDescription.displayName = SheetPrimitive.Description.displayName
+));
+SheetDescription.displayName = SheetPrimitive.Description.displayName;
 
 export {
   Sheet,
@@ -141,4 +141,4 @@ export {
   SheetFooter,
   SheetTitle,
   SheetDescription,
-}
+};

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Skeleton({
   className,
@@ -9,7 +9,7 @@ function Skeleton({
       className={cn("animate-pulse rounded-md bg-muted", className)}
       {...props}
     />
-  )
+  );
 }
 
-export { Skeleton }
+export { Skeleton };

--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -1,9 +1,9 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as SwitchPrimitives from "@radix-ui/react-switch"
+import * as React from "react";
+import * as SwitchPrimitives from "@radix-ui/react-switch";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const Switch = React.forwardRef<
   React.ElementRef<typeof SwitchPrimitives.Root>,
@@ -23,7 +23,7 @@ const Switch = React.forwardRef<
       )}
     />
   </SwitchPrimitives.Root>
-))
-Switch.displayName = SwitchPrimitives.Root.displayName
+));
+Switch.displayName = SwitchPrimitives.Root.displayName;
 
-export { Switch }
+export { Switch };

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
+import * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const Table = React.forwardRef<
   HTMLTableElement,
@@ -13,16 +13,16 @@ const Table = React.forwardRef<
       {...props}
     />
   </div>
-))
-Table.displayName = "Table"
+));
+Table.displayName = "Table";
 
 const TableHeader = React.forwardRef<
   HTMLTableSectionElement,
   React.HTMLAttributes<HTMLTableSectionElement>
 >(({ className, ...props }, ref) => (
   <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
-))
-TableHeader.displayName = "TableHeader"
+));
+TableHeader.displayName = "TableHeader";
 
 const TableBody = React.forwardRef<
   HTMLTableSectionElement,
@@ -33,8 +33,8 @@ const TableBody = React.forwardRef<
     className={cn("[&_tr:last-child]:border-0", className)}
     {...props}
   />
-))
-TableBody.displayName = "TableBody"
+));
+TableBody.displayName = "TableBody";
 
 const TableFooter = React.forwardRef<
   HTMLTableSectionElement,
@@ -48,8 +48,8 @@ const TableFooter = React.forwardRef<
     )}
     {...props}
   />
-))
-TableFooter.displayName = "TableFooter"
+));
+TableFooter.displayName = "TableFooter";
 
 const TableRow = React.forwardRef<
   HTMLTableRowElement,
@@ -63,8 +63,8 @@ const TableRow = React.forwardRef<
     )}
     {...props}
   />
-))
-TableRow.displayName = "TableRow"
+));
+TableRow.displayName = "TableRow";
 
 const TableHead = React.forwardRef<
   HTMLTableCellElement,
@@ -78,8 +78,8 @@ const TableHead = React.forwardRef<
     )}
     {...props}
   />
-))
-TableHead.displayName = "TableHead"
+));
+TableHead.displayName = "TableHead";
 
 const TableCell = React.forwardRef<
   HTMLTableCellElement,
@@ -90,8 +90,8 @@ const TableCell = React.forwardRef<
     className={cn("p-4 align-middle [&:has([role=checkbox])]:pr-0", className)}
     {...props}
   />
-))
-TableCell.displayName = "TableCell"
+));
+TableCell.displayName = "TableCell";
 
 const TableCaption = React.forwardRef<
   HTMLTableCaptionElement,
@@ -102,8 +102,8 @@ const TableCaption = React.forwardRef<
     className={cn("mt-4 text-sm text-muted-foreground", className)}
     {...props}
   />
-))
-TableCaption.displayName = "TableCaption"
+));
+TableCaption.displayName = "TableCaption";
 
 export {
   Table,
@@ -114,4 +114,4 @@ export {
   TableRow,
   TableCell,
   TableCaption,
-}
+};

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -1,11 +1,11 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as TabsPrimitive from "@radix-ui/react-tabs"
+import * as React from "react";
+import * as TabsPrimitive from "@radix-ui/react-tabs";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-const Tabs = TabsPrimitive.Root
+const Tabs = TabsPrimitive.Root;
 
 const TabsList = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.List>,
@@ -19,8 +19,8 @@ const TabsList = React.forwardRef<
     )}
     {...props}
   />
-))
-TabsList.displayName = TabsPrimitive.List.displayName
+));
+TabsList.displayName = TabsPrimitive.List.displayName;
 
 const TabsTrigger = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Trigger>,
@@ -34,8 +34,8 @@ const TabsTrigger = React.forwardRef<
     )}
     {...props}
   />
-))
-TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+));
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
 
 const TabsContent = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Content>,
@@ -49,7 +49,7 @@ const TabsContent = React.forwardRef<
     )}
     {...props}
   />
-))
-TabsContent.displayName = TabsPrimitive.Content.displayName
+));
+TabsContent.displayName = TabsPrimitive.Content.displayName;
 
-export { Tabs, TabsList, TabsTrigger, TabsContent }
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
+import * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 export interface TextareaProps
   extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
@@ -16,9 +16,9 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
         ref={ref}
         {...props}
       />
-    )
+    );
   }
-)
-Textarea.displayName = "Textarea"
+);
+Textarea.displayName = "Textarea";
 
-export { Textarea }
+export { Textarea };

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -1,15 +1,15 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+import * as React from "react";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-const TooltipProvider = TooltipPrimitive.Provider
+const TooltipProvider = TooltipPrimitive.Provider;
 
-const Tooltip = TooltipPrimitive.Root
+const Tooltip = TooltipPrimitive.Root;
 
-const TooltipTrigger = TooltipPrimitive.Trigger
+const TooltipTrigger = TooltipPrimitive.Trigger;
 
 const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
@@ -24,7 +24,7 @@ const TooltipContent = React.forwardRef<
     )}
     {...props}
   />
-))
-TooltipContent.displayName = TooltipPrimitive.Content.displayName
+));
+TooltipContent.displayName = TooltipPrimitive.Content.displayName;
 
-export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/hooks/use-debounce.ts
+++ b/hooks/use-debounce.ts
@@ -5,12 +5,12 @@ export function useDebounce<T>(value: T, delay?:number): T {
 
     useEffect(() => {
         const timer = setTimeout(() => {
-            setDebounceValue(value)
+            setDebounceValue(value);
         }, delay || 500);
 
         return () => {
             clearTimeout(timer);
-        }
+        };
     }, [value, delay]);
 
     return debounceValue;

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -2,5 +2,5 @@ export const formatPrice = (price: number) => {
     return new Intl.NumberFormat("en-US", {
         style: "currency",
         currency: "USD"
-    }).format(price)
-}
+    }).format(price);
+};

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -3,4 +3,4 @@ import Stripe from "stripe";
 export const stripe = new Stripe(process.env.STRIPE_API_KEY!, {
     apiVersion: "2024-04-10",
     typescript: true,
-})
+});

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,8 +1,8 @@
-import { type ClassValue, clsx } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
 }
 
 export function timeAgo(date: Date | string): string {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,6 @@
 
 import { withUt } from "uploadthing/tw";
-import type { Config } from "tailwindcss"
+import type { Config } from "tailwindcss";
 
 const config = withUt({
   darkMode: ["class"],
@@ -141,6 +141,6 @@ const config = withUt({
   	}
   },
   plugins: [require("tailwindcss-animate")],
-}) satisfies Config
+}) satisfies Config;
 
-export default config
+export default config;


### PR DESCRIPTION
The scope held back from #145, done as its own change so the mechanical diff doesn't bury a security fix.

**Both rules are enabled, not just the findings fixed.** Fixing without enabling means the same cruft returns the next time someone copies a nearby file — which is how it accumulated.

## A correction to #145

I reported "341 unused-vars repo-wide" in that PR. **That number was wrong.**

`@typescript-eslint` was installed but never listed in `.eslintrc.json`, so running the rule reported *"Definition for rule '@typescript-eslint/no-unused-vars' was not found"* — once per file. I counted those 341 lines as 341 violations. The real count is **22**. (`semi` was 538, not 544; the earlier figure included the same noise.)

This PR registers the plugin, so the rule actually runs.

## What changed

**538 semicolons** — pure autofix, no behaviour change. That's most of the diff.

**22 unused variables, 19 of them mine:**

- 14 pages kept an unused `redirect` import after `requirePagePrincipal` took over the redirect itself.
- 5 handlers kept a `const userId` that only the hand-rolled ownership block used, before `authorizeCourse` replaced it.

Both are the tail of the sweeps in #142. Removing them.

## The other three are a real finding

`attachment-form.tsx`, `image-form.tsx`, and `chapter-video-form.tsx` each declare a zod schema, use it **only** through `z.infer<typeof formSchema>`, and submit from a callback rather than through `zodResolver` — so the schema documents a shape that nothing enforces:

```ts
const formSchema = z.object({ url: z.string().min(1) });   // never validated against
const onSubmit = async (values: z.infer<typeof formSchema>) => { ... }
// ...
onSubmit({ url: url });   // called directly from the upload callback
```

Sibling forms in the same directory *do* pass it to `zodResolver`. So this is an inconsistency, not a deliberate pattern.

I left each in place with a comment saying so, rather than either deleting the schema (which erases the finding) or wiring up `zodResolver` (a behaviour change that doesn't belong in a lint sweep, and could start rejecting submissions). Worth a follow-up with the form work.

Note this is client-side only — it isn't a security boundary. Server-side bounded validation is #44.

## Verification

Both rules confirmed to fire on new code:

```
2:7   error  'unusedThing' is assigned a value but never used   @typescript-eslint/no-unused-vars
2:22  error  Missing semicolon                                  semi
```

```
npm run validate         # exit 0
npm run test:integration # 32 passed
npm run build

Test Files  15 passed (15)
     Tests  384 passed (384)
```

97 files changed, but 96 of them are semicolons. Reviewing the non-semicolon changes is `.eslintrc.json`, the three schema comments, and the removed imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RH1AUJJFKCXc2SuRcML9vg
