### PR TITLE
feat: separate the runtime and migration database roles (#43 phase 1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,14 @@
 DATABASE_URL="postgresql://postgres:postgres@localhost:5433/akomapa?schema=public"
 # Direct (non-pooler) connection used by Prisma CLI for migrations.
 # Falls back to DATABASE_URL if unset. Use the direct URL when DATABASE_URL is pooled.
+# Two roles, not one (ADR 0003). DATABASE_URL is the unprivileged application
+# role that row-level security applies to; DIRECT_URL is the privileged role
+# that owns the schema and applies migrations. If DIRECT_URL is unset the CLI
+# falls back to DATABASE_URL, which stops working once the runtime role loses
+# DDL rights -- deliberately, and loudly, at deploy time.
+#
+# Create both with scripts/sql/create-database-roles.sql, then verify with
+# `npm run db:roles`. See docs/runbooks/database-roles.md.
 DIRECT_URL="postgresql://postgres:postgres@localhost:5433/akomapa?schema=public"
 
 # -----------------------------------------------------------------------------

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,10 @@ CHANGELOG.md
 # The permission matrix: the authorization rules every contributor and agent
 # must implement against, asserted by tests/unit/auth/policy.test.ts.
 !/docs/permission-matrix.md
+# Operational runbooks: procedures a deploy or an incident depends on. A runbook
+# that exists only on one machine is not a runbook.
+!/docs/runbooks/
+!/docs/runbooks/**
 # Phase specifications: the historical record the release matrix audits
 # against. Committed so that audit is reproducible by anyone.
 !/docs/phase-1.md

--- a/docs/runbooks/database-roles.md
+++ b/docs/runbooks/database-roles.md
@@ -1,0 +1,92 @@
+# Database roles
+
+How Akomapa Academy connects to PostgreSQL, and why it uses two roles rather
+than one. Implements [ADR 0003](../adr/0003-rls-and-transaction-scoped-principal.md);
+owned by [#43](https://github.com/akomapahealth/akomapa-lms/issues/43).
+
+## The two roles
+
+| Role | Used by | Privileges |
+| --- | --- | --- |
+| `akomapa_migrate` | `prisma migrate deploy`, maintenance | Owns schema `public`, may DDL |
+| `akomapa_app` | All runtime traffic | `SELECT`/`INSERT`/`UPDATE`/`DELETE` only |
+
+Neither may be a superuser and neither may hold `BYPASSRLS`. **A superuser
+ignores row-level security unconditionally**, whatever `rolbypassrls` says, so
+checking only the obvious attribute would pass the configuration most
+deployments start from.
+
+Ownership is the subtle half. **A table's owner bypasses that table's policies**
+unless the table is set to `FORCE ROW LEVEL SECURITY`. The application must
+therefore not own its tables, and keeping migrations under a separate role makes
+that true by construction rather than by remembering.
+
+`akomapa_app` deliberately has no `TRUNCATE`: truncation is not subject to
+row-level security, so a policy could not restrain it.
+
+## Environment variables
+
+| Variable | Role | Read by |
+| --- | --- | --- |
+| `DATABASE_URL` | `akomapa_app` | The application at runtime |
+| `DIRECT_URL` | `akomapa_migrate` | The Prisma CLI, via `prisma.config.ts` |
+
+`prisma.config.ts` already prefers `DIRECT_URL` and falls back to
+`DATABASE_URL`, so `npm run build` — which runs `prisma migrate deploy` — picks
+up the privileged role automatically once `DIRECT_URL` is set. **If `DIRECT_URL`
+is unset, migrations run as the runtime role and will fail** once that role
+loses DDL rights. That is the intended failure: loud, at deploy time.
+
+## Creating the roles
+
+`scripts/sql/create-database-roles.sql` is idempotent and safe to re-run. Set
+real passwords first — the file ships placeholders.
+
+Locally, as a superuser:
+
+```
+psql "$DATABASE_URL" -f scripts/sql/create-database-roles.sql
+```
+
+On a managed provider without a superuser shell (Neon), paste it into the SQL
+console. Then update both connection strings.
+
+## Verifying
+
+```
+npm run db:roles
+```
+
+Reports what each connection string can do and exits non-zero if the runtime
+role could ignore row-level security, if it can create objects, or if both URLs
+resolve to the same role. Aim it at another environment with a shell prefix:
+
+```
+DATABASE_URL="postgresql://..." DIRECT_URL="postgresql://..." npm run db:roles
+```
+
+An exported value beats the dotenv files.
+
+`assertRuntimeRoleCannotBypassRls()` in `lib/db/roles.ts` is the same assertion
+as a function, ready for the readiness endpoint in
+[#103](https://github.com/akomapahealth/akomapa-lms/issues/103). Until that
+exists, `npm run db:roles` is a **manual** deploy step — CI has no production
+database.
+
+## What this does not do yet
+
+No policies exist and row-level security is not enabled on any table, so this
+change alters no behaviour: `akomapa_app` currently sees everything, exactly as
+before. Splitting the roles first means the later phases of #43 can enable
+policies table by table and have them actually apply.
+
+Order of the remaining phases:
+
+1. **Roles and wiring** — this change.
+2. **Transaction wrapper** — every query runs inside a transaction that sets
+   `app.user_id` and `app.user_role` with `SET LOCAL`, so a pooled connection
+   cannot carry a principal into the next request. 223 call sites.
+3. **Policies** — enabled per table, each with a test that fails without it.
+
+Enabling policies before step 2 would make every query return nothing. That is
+the ordering constraint the phases exist to respect.

--- a/lib/db/roles.ts
+++ b/lib/db/roles.ts
@@ -1,0 +1,76 @@
+import "server-only";
+
+import { db } from "@/lib/db";
+
+/**
+ * What the database says about the role a connection is using.
+ *
+ * ADR 0003 makes row-level security the second enforcement layer, and a second
+ * layer that silently isn't enforcing is worse than none: it invites the first
+ * layer to be trusted less. So the property is checked rather than assumed.
+ *
+ * The check has to survive being wrong in the quiet direction. A role that can
+ * bypass RLS does not error -- it returns *more* rows, which looks like the
+ * application working.
+ */
+export interface RoleCapabilities {
+  role: string;
+  /** Superusers ignore row-level security unconditionally, flag or no flag. */
+  isSuperuser: boolean;
+  /** The explicit BYPASSRLS attribute. */
+  hasBypassRls: boolean;
+}
+
+export async function describeCurrentRole(): Promise<RoleCapabilities> {
+  const rows = await db.$queryRaw<
+    { role: string; is_superuser: boolean; has_bypass_rls: boolean }[]
+  >`
+    SELECT rolname       AS role,
+           rolsuper      AS is_superuser,
+           rolbypassrls  AS has_bypass_rls
+      FROM pg_roles
+     WHERE rolname = current_user
+  `;
+
+  if (rows.length === 0) {
+    // current_user always exists in pg_roles; an empty result means the query
+    // did not run against the database we think it did.
+    throw new Error("Could not resolve the current database role.");
+  }
+
+  return {
+    role: rows[0].role,
+    isSuperuser: rows[0].is_superuser,
+    hasBypassRls: rows[0].has_bypass_rls,
+  };
+}
+
+/** True when this role would ignore row-level security policies. */
+export function bypassesRowLevelSecurity(capabilities: RoleCapabilities): boolean {
+  // Either attribute is sufficient on its own. Checking only BYPASSRLS would
+  // pass a superuser, which is the configuration most deployments start from.
+  return capabilities.isSuperuser || capabilities.hasBypassRls;
+}
+
+/**
+ * Fails if runtime traffic would ignore row-level security.
+ *
+ * Intended for the readiness check in
+ * [#103](https://github.com/akomapahealth/akomapa-lms/issues/103), so a
+ * misconfigured environment refuses to serve rather than serving everything.
+ * Until that endpoint exists, `npm run db:roles` runs the same assertion as a
+ * deploy step.
+ */
+export async function assertRuntimeRoleCannotBypassRls(): Promise<void> {
+  const capabilities = await describeCurrentRole();
+
+  if (bypassesRowLevelSecurity(capabilities)) {
+    const reason = capabilities.isSuperuser ? "is a superuser" : "has BYPASSRLS";
+    throw new Error(
+      `The runtime database role "${capabilities.role}" ${reason}, so row-level ` +
+        `security policies would not apply to it. Point DATABASE_URL at the ` +
+        `unprivileged application role and keep the privileged role in ` +
+        `DIRECT_URL. See scripts/sql/create-database-roles.sql.`
+    );
+  }
+}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "role:find": "tsx scripts/manage-roles.ts find",
     "role:list": "tsx scripts/manage-roles.ts list",
     "role:check": "tsx scripts/manage-roles.ts check",
+    "db:roles": "tsx scripts/check-database-roles.ts",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "prepare": "husky"

--- a/scripts/check-database-roles.ts
+++ b/scripts/check-database-roles.ts
@@ -1,0 +1,149 @@
+/**
+ * Reports what DATABASE_URL and DIRECT_URL can do, and fails if the runtime
+ * role could ignore row-level security.
+ *
+ * ADR 0003 makes RLS the second enforcement layer. A second layer that is
+ * silently not enforcing is worse than none, because it invites the first to be
+ * trusted less -- and the failure is quiet: a bypassing role returns *more*
+ * rows, which looks like the application working.
+ *
+ *   npm run db:roles
+ *
+ * Intended as a deploy step until #103 provides a readiness endpoint to mount
+ * `assertRuntimeRoleCannotBypassRls` on.
+ */
+import { config } from "dotenv";
+import { Client } from "pg";
+
+// An exported value beats the dotenv files, so aiming this at production is one
+// shell prefix. `.env.local` is loaded with override, so the shell value has to
+// be captured first or it is silently discarded.
+const explicit = {
+  DATABASE_URL: process.env.DATABASE_URL,
+  DIRECT_URL: process.env.DIRECT_URL,
+};
+
+config();
+config({ path: ".env.local", override: true });
+
+for (const [key, value] of Object.entries(explicit)) {
+  if (value) process.env[key] = value;
+}
+
+interface Capabilities {
+  role: string;
+  isSuperuser: boolean;
+  hasBypassRls: boolean;
+  canCreate: boolean;
+}
+
+function describeTarget(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.host}${parsed.pathname}`;
+  } catch {
+    return "(unparseable)";
+  }
+}
+
+async function inspect(connectionString: string): Promise<Capabilities> {
+  const client = new Client({ connectionString });
+  await client.connect();
+
+  try {
+    const { rows } = await client.query<{
+      role: string;
+      rolsuper: boolean;
+      rolbypassrls: boolean;
+      can_create: boolean;
+    }>(`
+      SELECT rolname AS role, rolsuper, rolbypassrls,
+             has_schema_privilege(current_user, 'public', 'CREATE') AS can_create
+        FROM pg_roles WHERE rolname = current_user
+    `);
+
+    const row = rows[0];
+    return {
+      role: row.role,
+      isSuperuser: row.rolsuper,
+      hasBypassRls: row.rolbypassrls,
+      canCreate: row.can_create,
+    };
+  } finally {
+    await client.end();
+  }
+}
+
+function report(label: string, url: string, caps: Capabilities) {
+  console.log(`${label}  ${describeTarget(url)}`);
+  console.log(`  role         ${caps.role}`);
+  console.log(`  superuser    ${caps.isSuperuser}`);
+  console.log(`  bypassrls    ${caps.hasBypassRls}`);
+  console.log(`  can DDL      ${caps.canCreate}`);
+}
+
+async function main() {
+  const runtimeUrl = process.env.DATABASE_URL;
+  const migrationUrl = process.env.DIRECT_URL;
+
+  if (!runtimeUrl) {
+    console.error("DATABASE_URL is not set.");
+    process.exitCode = 1;
+    return;
+  }
+
+  const runtime = await inspect(runtimeUrl);
+  report("runtime   (DATABASE_URL)", runtimeUrl, runtime);
+
+  let migration: Capabilities | null = null;
+  if (migrationUrl) {
+    migration = await inspect(migrationUrl);
+    console.log();
+    report("migration (DIRECT_URL)  ", migrationUrl, migration);
+  }
+
+  console.log();
+
+  const problems: string[] = [];
+
+  if (runtime.isSuperuser || runtime.hasBypassRls) {
+    problems.push(
+      `the runtime role "${runtime.role}" would ignore row-level security ` +
+        `(${runtime.isSuperuser ? "superuser" : "BYPASSRLS"})`
+    );
+  }
+
+  if (runtime.canCreate) {
+    // Not fatal on its own, but the application has no reason to create
+    // objects, and an owner bypasses its own table's policies.
+    problems.push(
+      `the runtime role "${runtime.role}" can create objects in schema public`
+    );
+  }
+
+  if (!migrationUrl) {
+    problems.push(
+      "DIRECT_URL is not set, so migrations would run as the runtime role"
+    );
+  } else if (migration && migration.role === runtime.role) {
+    problems.push(
+      "DIRECT_URL and DATABASE_URL use the same role, so there is no separation"
+    );
+  }
+
+  if (problems.length > 0) {
+    console.error("FAIL");
+    for (const problem of problems) console.error(`  - ${problem}`);
+    console.error("\nFix: scripts/sql/create-database-roles.sql");
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log("OK: the runtime role is subject to row-level security, and");
+  console.log("    migrations run as a separate privileged role.");
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : "Unknown error");
+  process.exitCode = 1;
+});

--- a/scripts/sql/create-database-roles.sql
+++ b/scripts/sql/create-database-roles.sql
@@ -1,0 +1,71 @@
+-- Database roles for Akomapa Academy (ADR 0003, issue #43).
+--
+-- Two roles, because row-level security only means anything if the role the
+-- application runs as cannot ignore it:
+--
+--   akomapa_migrate  owns the schema and applies migrations. Privileged.
+--   akomapa_app      serves runtime traffic. Cannot bypass RLS, owns nothing.
+--
+-- Ownership is the subtle half. A table's owner bypasses that table's policies
+-- unless the table is set to FORCE ROW LEVEL SECURITY, so the application must
+-- not own its tables. Keeping migrations under a separate role is what makes
+-- that true by construction rather than by remembering.
+--
+-- Idempotent: safe to re-run, and safe to run before the policies exist.
+-- Run it as a superuser (locally) or via the provider's SQL console (Neon).
+-- Passwords are placeholders; set real ones before running, and put them in
+-- DATABASE_URL (akomapa_app) and DIRECT_URL (akomapa_migrate).
+
+\set ON_ERROR_STOP on
+
+-- ── Roles ────────────────────────────────────────────────────────────────────
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'akomapa_migrate') THEN
+    CREATE ROLE akomapa_migrate LOGIN PASSWORD 'CHANGE_ME_MIGRATE';
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'akomapa_app') THEN
+    CREATE ROLE akomapa_app LOGIN PASSWORD 'CHANGE_ME_APP';
+  END IF;
+END
+$$;
+
+-- Stated explicitly rather than relying on defaults, so re-running this file
+-- repairs a role that was altered by hand.
+ALTER ROLE akomapa_migrate NOSUPERUSER NOBYPASSRLS CREATEDB;
+ALTER ROLE akomapa_app     NOSUPERUSER NOBYPASSRLS NOCREATEDB NOCREATEROLE;
+
+-- ── Schema ownership ─────────────────────────────────────────────────────────
+
+ALTER SCHEMA public OWNER TO akomapa_migrate;
+
+GRANT USAGE ON SCHEMA public TO akomapa_app;
+-- The application never creates objects; migrations do.
+REVOKE CREATE ON SCHEMA public FROM akomapa_app;
+REVOKE CREATE ON SCHEMA public FROM PUBLIC;
+
+-- ── Runtime privileges ───────────────────────────────────────────────────────
+
+-- Data, not structure. No TRUNCATE and no REFERENCES: both are structural, and
+-- TRUNCATE is not subject to row-level security.
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO akomapa_app;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO akomapa_app;
+
+-- The same privileges on anything a future migration creates. Without this,
+-- every migration that adds a table would silently break the application until
+-- someone remembered to grant it.
+ALTER DEFAULT PRIVILEGES FOR ROLE akomapa_migrate IN SCHEMA public
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO akomapa_app;
+ALTER DEFAULT PRIVILEGES FOR ROLE akomapa_migrate IN SCHEMA public
+  GRANT USAGE, SELECT ON SEQUENCES TO akomapa_app;
+
+-- ── Verification ─────────────────────────────────────────────────────────────
+
+-- Both roles must report f/f. `npm run db:roles` asserts the same thing against
+-- the connection strings the application actually uses.
+SELECT rolname, rolsuper, rolbypassrls
+  FROM pg_roles
+ WHERE rolname IN ('akomapa_app', 'akomapa_migrate')
+ ORDER BY rolname;

--- a/tests/integration/database-roles.test.ts
+++ b/tests/integration/database-roles.test.ts
@@ -1,0 +1,215 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Client } from "pg";
+
+import { testConnectionString, testPool } from "./support/db";
+
+/**
+ * The two-role model from ADR 0003, exercised against a real cluster.
+ *
+ * Roles are cluster-wide rather than per-database, so these tests create their
+ * own uniquely named pair and drop it again. Using the production names would
+ * leak state between workers and into the developer's own cluster.
+ *
+ * Nothing here enables row-level security on the application's tables -- that
+ * is a later phase of #43. What it proves is that the role separation works,
+ * so that when policies do arrive they will actually apply.
+ */
+const suffix = `${process.env.VITEST_WORKER_ID ?? "0"}_${process.pid}`;
+const APP_ROLE = `akomapa_t_app_${suffix}`;
+const MIGRATE_ROLE = `akomapa_t_migrate_${suffix}`;
+const PASSWORD = "test_only_password";
+
+let database: string;
+let host: string;
+let port: number;
+
+async function asSuperuser<T>(fn: (client: Client) => Promise<T>): Promise<T> {
+  const client = await testPool().connect();
+  try {
+    return await fn(client as unknown as Client);
+  } finally {
+    client.release();
+  }
+}
+
+/** Connects as one of the created roles, to the same test database. */
+async function connectAs(role: string): Promise<Client> {
+  const client = new Client({
+    host,
+    port,
+    database,
+    user: role,
+    password: PASSWORD,
+  });
+  await client.connect();
+  return client;
+}
+
+beforeEach(async () => {
+  const parsed = new URL(testConnectionString());
+  database = parsed.pathname.replace(/^\//, "");
+  host = parsed.hostname;
+  port = Number(parsed.port || 5432);
+
+  await asSuperuser(async (client) => {
+    // The same shape as scripts/sql/create-database-roles.sql, with test names.
+    await client.query(`CREATE ROLE ${MIGRATE_ROLE} LOGIN PASSWORD '${PASSWORD}'`);
+    await client.query(`CREATE ROLE ${APP_ROLE} LOGIN PASSWORD '${PASSWORD}'`);
+    await client.query(`ALTER ROLE ${MIGRATE_ROLE} NOSUPERUSER NOBYPASSRLS`);
+    await client.query(`ALTER ROLE ${APP_ROLE} NOSUPERUSER NOBYPASSRLS NOCREATEDB NOCREATEROLE`);
+    await client.query(`GRANT USAGE ON SCHEMA public TO ${APP_ROLE}, ${MIGRATE_ROLE}`);
+    await client.query(`GRANT CREATE ON SCHEMA public TO ${MIGRATE_ROLE}`);
+    await client.query(`REVOKE CREATE ON SCHEMA public FROM ${APP_ROLE}`);
+    await client.query(
+      `GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO ${APP_ROLE}`
+    );
+    await client.query(
+      `GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO ${APP_ROLE}`
+    );
+  });
+});
+
+afterEach(async () => {
+  await asSuperuser(async (client) => {
+    for (const role of [APP_ROLE, MIGRATE_ROLE]) {
+      await client.query(`REASSIGN OWNED BY ${role} TO CURRENT_USER`).catch(() => {});
+      await client.query(`DROP OWNED BY ${role}`).catch(() => {});
+      await client.query(`DROP ROLE IF EXISTS ${role}`).catch(() => {});
+    }
+  });
+});
+
+describe("role attributes", () => {
+  it("gives neither role the ability to ignore row-level security", async () => {
+    const rows = await asSuperuser(async (client) => {
+      const result = await client.query<{
+        rolname: string;
+        rolsuper: boolean;
+        rolbypassrls: boolean;
+      }>(
+        `SELECT rolname, rolsuper, rolbypassrls FROM pg_roles
+          WHERE rolname IN ($1, $2) ORDER BY rolname`,
+        [APP_ROLE, MIGRATE_ROLE]
+      );
+      return result.rows;
+    });
+
+    expect(rows).toHaveLength(2);
+    for (const row of rows) {
+      // A superuser ignores policies whatever rolbypassrls says, so both
+      // attributes have to be false, not just the obvious one.
+      expect(row.rolsuper).toBe(false);
+      expect(row.rolbypassrls).toBe(false);
+    }
+  });
+
+  it("lets the application read and write data", async () => {
+    const app = await connectAs(APP_ROLE);
+    try {
+      await app.query(
+        `INSERT INTO "User" (id, email, role, "createdAt", "updatedAt")
+         VALUES ('user_role_test', 'r@example.test', 'STUDENT', now(), now())`
+      );
+      const { rows } = await app.query(`SELECT id FROM "User"`);
+      expect(rows).toHaveLength(1);
+    } finally {
+      await app.end();
+    }
+  });
+
+  it("does not let the application change the schema", async () => {
+    const app = await connectAs(APP_ROLE);
+    try {
+      // The application has no reason to create objects, and an object's owner
+      // bypasses that object's policies.
+      await expect(app.query(`CREATE TABLE should_not_exist (id text)`)).rejects.toThrow(
+        /permission denied/i
+      );
+    } finally {
+      await app.end();
+    }
+  });
+
+  it("does not let the application truncate, which policies cannot restrain", async () => {
+    const app = await connectAs(APP_ROLE);
+    try {
+      await expect(app.query(`TRUNCATE TABLE "User"`)).rejects.toThrow(/permission denied/i);
+    } finally {
+      await app.end();
+    }
+  });
+});
+
+describe("row-level security actually applies to the application role", () => {
+  beforeEach(async () => {
+    await asSuperuser(async (client) => {
+      await client.query(`CREATE TABLE rls_probe (id text PRIMARY KEY, owner text NOT NULL)`);
+      await client.query(`INSERT INTO rls_probe VALUES ('a', 'alice'), ('b', 'bob')`);
+      await client.query(`ALTER TABLE rls_probe ENABLE ROW LEVEL SECURITY`);
+      await client.query(`ALTER TABLE rls_probe FORCE ROW LEVEL SECURITY`);
+      await client.query(
+        `CREATE POLICY owner_only ON rls_probe
+           USING (owner = current_setting('app.user_id', true))`
+      );
+      await client.query(`GRANT SELECT ON rls_probe TO ${APP_ROLE}`);
+    });
+  });
+
+  afterEach(async () => {
+    await asSuperuser((client) => client.query(`DROP TABLE IF EXISTS rls_probe`));
+  });
+
+  it("returns only the rows the transaction-scoped principal owns", async () => {
+    const app = await connectAs(APP_ROLE);
+    try {
+      await app.query("BEGIN");
+      // set_config with is_local => true dies with the transaction, which is
+      // what makes this safe on a pooled connection (ADR 0003 section 2).
+      await app.query(`SELECT set_config('app.user_id', 'alice', true)`);
+      const { rows } = await app.query(`SELECT id FROM rls_probe`);
+      await app.query("COMMIT");
+
+      expect(rows.map((r) => r.id)).toEqual(["a"]);
+    } finally {
+      await app.end();
+    }
+  });
+
+  it("returns nothing when no principal is set", async () => {
+    // The failure mode ADR 0003 warns about: a missing principal looks like
+    // missing data, not like an error.
+    const app = await connectAs(APP_ROLE);
+    try {
+      const { rows } = await app.query(`SELECT id FROM rls_probe`);
+      expect(rows).toHaveLength(0);
+    } finally {
+      await app.end();
+    }
+  });
+
+  it("does not leak the principal to the next transaction on the same connection", async () => {
+    // The specific failure the transaction-scoped design exists to prevent.
+    const app = await connectAs(APP_ROLE);
+    try {
+      await app.query("BEGIN");
+      await app.query(`SELECT set_config('app.user_id', 'alice', true)`);
+      await app.query("COMMIT");
+
+      const { rows } = await app.query(`SELECT id FROM rls_probe`);
+      expect(rows).toHaveLength(0);
+    } finally {
+      await app.end();
+    }
+  });
+
+  it("is ignored by a superuser, which is why the runtime role must not be one", async () => {
+    const rows = await asSuperuser(async (client) => {
+      const result = await client.query(`SELECT id FROM rls_probe`);
+      return result.rows;
+    });
+
+    // Both rows, no policy applied, no principal set. This is what a
+    // misconfigured DATABASE_URL buys: everything, quietly.
+    expect(rows).toHaveLength(2);
+  });
+});

--- a/tests/integration/support/db.ts
+++ b/tests/integration/support/db.ts
@@ -13,8 +13,10 @@ import { Pool } from "pg";
  */
 let pool: Pool | undefined;
 let client: PrismaClient | undefined;
+let url: string | undefined;
 
 export async function connectTestDatabase(connectionString: string) {
+  url = connectionString;
   pool = new Pool({ connectionString });
   client = new PrismaClient({ adapter: new PrismaPg(pool) });
   await client.$queryRaw`SELECT 1`;
@@ -28,6 +30,17 @@ export function testDb(): PrismaClient {
     );
   }
   return client;
+}
+
+/**
+ * The connection string in use, for tests that need to open a second
+ * connection as a different role. Asking the server for its own host and port
+ * does not work: `inet_server_port()` is null over a unix socket, and the
+ * answer would be the server's view rather than the client's route to it.
+ */
+export function testConnectionString(): string {
+  if (!url) throw new Error("The test database is not connected.");
+  return url;
 }
 
 /** The raw pool, for statements Prisma cannot express. */

--- a/tests/unit/db/roles.test.ts
+++ b/tests/unit/db/roles.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { dbMock } from "../support/db";
+
+vi.mock("@/lib/db", async () => ({ db: (await import("../support/db")).dbMock }));
+
+const { assertRuntimeRoleCannotBypassRls, bypassesRowLevelSecurity, describeCurrentRole } =
+  await import("@/lib/db/roles");
+
+/**
+ * The guard that stops row-level security from being silently absent.
+ *
+ * A bypassing role does not error. It returns *more* rows, which looks exactly
+ * like the application working, so the condition has to be asserted rather than
+ * noticed.
+ */
+/**
+ * Resolved per call, not captured once: the shared double is rebuilt before
+ * every test, so a reference taken at module scope points at a stale mock.
+ */
+const queryRaw = () =>
+  dbMock.$queryRaw as unknown as { mockResolvedValue: (value: unknown) => void };
+
+function roleIs(overrides: { rolsuper?: boolean; rolbypassrls?: boolean } = {}) {
+  queryRaw().mockResolvedValue([
+    {
+      role: "akomapa_app",
+      is_superuser: overrides.rolsuper ?? false,
+      has_bypass_rls: overrides.rolbypassrls ?? false,
+    },
+  ]);
+}
+
+describe("bypassesRowLevelSecurity", () => {
+  it("is false only when the role is neither superuser nor BYPASSRLS", () => {
+    expect(
+      bypassesRowLevelSecurity({ role: "a", isSuperuser: false, hasBypassRls: false })
+    ).toBe(false);
+  });
+
+  it("is true for a superuser even without the BYPASSRLS attribute", () => {
+    // The configuration most deployments start from. Checking only
+    // rolbypassrls would pass it.
+    expect(
+      bypassesRowLevelSecurity({ role: "postgres", isSuperuser: true, hasBypassRls: false })
+    ).toBe(true);
+  });
+
+  it("is true for BYPASSRLS without superuser", () => {
+    expect(
+      bypassesRowLevelSecurity({ role: "a", isSuperuser: false, hasBypassRls: true })
+    ).toBe(true);
+  });
+});
+
+describe("describeCurrentRole", () => {
+  it("reports what the database says about the connected role", async () => {
+    roleIs({ rolbypassrls: true });
+
+    await expect(describeCurrentRole()).resolves.toEqual({
+      role: "akomapa_app",
+      isSuperuser: false,
+      hasBypassRls: true,
+    });
+  });
+
+  it("fails rather than assuming when the role cannot be resolved", async () => {
+    // current_user is always in pg_roles, so an empty result means the query
+    // did not run where we think it did.
+    queryRaw().mockResolvedValue([]);
+
+    await expect(describeCurrentRole()).rejects.toThrow(/could not resolve/i);
+  });
+});
+
+describe("assertRuntimeRoleCannotBypassRls", () => {
+  it("passes for an unprivileged role", async () => {
+    roleIs();
+
+    await expect(assertRuntimeRoleCannotBypassRls()).resolves.toBeUndefined();
+  });
+
+  it("fails for a superuser and says which attribute is at fault", async () => {
+    roleIs({ rolsuper: true });
+
+    await expect(assertRuntimeRoleCannotBypassRls()).rejects.toThrow(/is a superuser/);
+  });
+
+  it("fails for BYPASSRLS and says so", async () => {
+    roleIs({ rolbypassrls: true });
+
+    await expect(assertRuntimeRoleCannotBypassRls()).rejects.toThrow(/has BYPASSRLS/);
+  });
+
+  it("names the remedy, since whoever hits this needs the fix not the diagnosis", async () => {
+    roleIs({ rolsuper: true });
+
+    await expect(assertRuntimeRoleCannotBypassRls()).rejects.toThrow(/DATABASE_URL/);
+    await expect(assertRuntimeRoleCannotBypassRls()).rejects.toThrow(
+      /create-database-roles\.sql/
+    );
+  });
+});

--- a/tests/unit/support/db.ts
+++ b/tests/unit/support/db.ts
@@ -56,9 +56,20 @@ function createDelegate(model: string): Delegate {
 
 function createDbMock() {
   const models = new Map<string, Delegate>();
+  const clientMethods = new Map<string, ReturnType<typeof vi.fn>>();
 
   return new Proxy({} as Record<string, Delegate>, {
     get(_target, prop: string) {
+      // Client-level methods are functions, not model delegates. Without this
+      // they would be handed back as an object named `$queryRaw`, and a test
+      // configuring one would fail on a missing `mockResolvedValue`.
+      if (prop === "$queryRaw" || prop === "$queryRawUnsafe" ||
+          prop === "$executeRaw" || prop === "$executeRawUnsafe") {
+        if (!clientMethods.has(prop)) {
+          clientMethods.set(prop, vi.fn().mockResolvedValue([]));
+        }
+        return clientMethods.get(prop)!;
+      }
       if (prop === "$transaction") {
         // Callback form runs inline against the same mock; array form resolves
         // each promise. Real transactional guarantees are #107's job.

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -50,6 +50,7 @@ export default defineConfig({
         "lib/courses/*.ts",
         "lib/assessments/*.ts",
         "lib/text/*.ts",
+        "lib/db/roles.ts",
         "lib/case-study-sanitize.ts",
         "lib/streak-service.ts",
         "lib/badge-service.ts",
@@ -81,6 +82,8 @@ export default defineConfig({
         // The stored-XSS boundary for author-written rich text.
         "lib/text/sanitize-html.ts": { lines: 100, functions: 100, branches: 100, statements: 100 },
         "lib/case-study-sanitize.ts": { lines: 100, functions: 100, branches: 100, statements: 100 },
+        // The guard that keeps row-level security from being silently absent.
+        "lib/db/roles.ts": { lines: 100, functions: 100, branches: 100, statements: 100 },
       },
     },
   },


### PR DESCRIPTION
Phase 1 of #43, implementing the role half of [ADR 0003](../blob/dev/docs/adr/0003-rls-and-transaction-scoped-principal.md).

**No policies are created and RLS is not enabled anywhere.** This changes no behaviour — the application still sees everything, exactly as before. Splitting the roles first is what will make the later policies actually apply.

## The two roles

| Role | Used by | Privileges |
| --- | --- | --- |
| `akomapa_migrate` | `prisma migrate deploy` | Owns schema `public`, may DDL |
| `akomapa_app` | All runtime traffic | `SELECT`/`INSERT`/`UPDATE`/`DELETE` only |

Two details drive the shape of `scripts/sql/create-database-roles.sql`:

**A superuser ignores RLS unconditionally**, whatever `rolbypassrls` says. Checking only the obvious attribute would pass the configuration most deployments start from — including this repo's local setup, which runs as `postgres`.

**A table's owner bypasses that table's policies** unless it's set to `FORCE ROW LEVEL SECURITY`. So the application must not own its tables, and keeping migrations under a separate role makes that true by construction rather than by remembering.

`akomapa_app` also has no `TRUNCATE` — truncation isn't subject to RLS, so a policy couldn't restrain it. Default privileges are granted for future tables too; without that, every migration adding a table would silently break the app until someone remembered to grant on it.

## Wiring

`prisma.config.ts` already prefers `DIRECT_URL` over `DATABASE_URL`, so this is setting a variable, not changing code. **If `DIRECT_URL` is unset, migrations run as the runtime role and fail** once that role loses DDL rights — loudly, at deploy time, which is the intended failure.

## Verifying

```
npm run db:roles
```

Run against the current local setup it reports the honest starting position:

```
runtime   (DATABASE_URL)  127.0.0.1:5433/akomapa
  role         postgres
  superuser    true
  bypassrls    true
  can DDL      true

FAIL
  - the runtime role "postgres" would ignore row-level security (superuser)
  - the runtime role "postgres" can create objects in schema public
  - DIRECT_URL and DATABASE_URL use the same role, so there is no separation
```

`assertRuntimeRoleCannotBypassRls()` is the same assertion as a function, ready for #103's readiness endpoint. Until that exists this is a manual deploy step — CI has no production database.

## Evidence

Integration tests create their own **uniquely named** role pair (roles are cluster-wide, so production names would leak between workers and into your own cluster) and prove the parts that de-risk the phases still to come:

- Policies **do** apply to the application role — it sees one row of two.
- A superuser **ignores** them entirely, seeing both. That's what a misconfigured `DATABASE_URL` buys: everything, quietly.
- A principal set with `set_config(..., is_local => true)` **dies with its transaction** rather than surviving on a pooled connection into the next request. That's the specific failure ADR 0003 exists to prevent, and it's now demonstrated rather than assumed.
- The app role cannot `CREATE TABLE` or `TRUNCATE`.

The SQL file was executed against a scratch database; both roles report `f | f`.

```
npm run validate         # exit 0
npm run test:integration # 44 passed
npm run build

Test Files  18 passed (18)
     Tests  426 passed (426)
```

## Operator steps (not required to merge)

Nothing breaks if you don't do this yet — the roles simply don't exist and everything keeps using the current one. When ready:

1. Set real passwords in `scripts/sql/create-database-roles.sql`, run it in the Neon SQL console.
2. Point `DATABASE_URL` at `akomapa_app` and `DIRECT_URL` at `akomapa_migrate` in Vercel.
3. `npm run db:roles` against production to confirm.

Full procedure in `docs/runbooks/database-roles.md`.

## Next

Phase 2 is the transaction wrapper across 223 call sites — `SET LOCAL` for `app.user_id` and `app.user_role`. Phase 3 enables policies table by table, each with a test that fails without it. **Enabling policies before phase 2 would make every query return nothing**, which is the ordering constraint these phases exist to respect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RH1AUJJFKCXc2SuRcML9vg
